### PR TITLE
Fix clear command history file handling

### DIFF
--- a/Commands/TerminalCommands/ConsoleSystem/ClearHistory.cs
+++ b/Commands/TerminalCommands/ConsoleSystem/ClearHistory.cs
@@ -9,17 +9,25 @@ namespace Commands.TerminalCommands.ConsoleSystem
      */
     public class ClearHistory : ITerminalCommand
     {
-        private static string s_historyFile = GlobalVariables.historyFile;
+        private static readonly string s_historyFile = GlobalVariables.historyFile;
         public string Name => "chistory";
+
         public void Execute(string arg)
         {
             if (File.Exists(s_historyFile))
             {
-                File.WriteAllText(s_historyFile, Environment.NewLine);
-                Console.WriteLine("Command history log cleared!");
+                try
+                {
+                    File.WriteAllText(s_historyFile, Environment.NewLine);
+                    Console.WriteLine("Command history log cleared!");
+                }
+                catch
+                {
+                    Console.WriteLine("Clearing command history log failed!");
+                }
                 return;
             }
-            Console.WriteLine("File '" + s_historyFile + "' dose not exist!");
+            Console.WriteLine($"File '{s_historyFile}' does not exist!");
         }
     }
 }


### PR DESCRIPTION
- Wrapped working with a file in a `try catch`, see this [blog post](https://www.meziantou.net/is-file-exist-path-useless.htm) for reference
- Fixed a typo