### PR TITLE
Fix typos and formatting

### DIFF
--- a/Commands/TerminalCommands/ConsoleSystem/ClearHistory.cs
+++ b/Commands/TerminalCommands/ConsoleSystem/ClearHistory.cs
@@ -19,7 +19,7 @@ namespace Commands.TerminalCommands.ConsoleSystem
                 Console.WriteLine("Command history log cleared!");
                 return;
             }
-            Console.WriteLine("File '" + s_historyFile + "' dose not exist!");
+            Console.WriteLine($"File '{s_historyFile}' does not exist!");
         }
     }
 }

--- a/Commands/TerminalCommands/ConsoleSystem/CommandHistory.cs
+++ b/Commands/TerminalCommands/ConsoleSystem/CommandHistory.cs
@@ -40,7 +40,7 @@ namespace Commands.TerminalCommands.ConsoleSystem
 
             if (!fileInfo.Exists)
             {
-                Console.WriteLine("History file not exists!");
+                Console.WriteLine("History file does not exist!");
                 return false;
             }
 

--- a/Commands/TerminalCommands/ConsoleSystem/CurrentDirectory.cs
+++ b/Commands/TerminalCommands/ConsoleSystem/CurrentDirectory.cs
@@ -36,7 +36,7 @@ namespace Commands.TerminalCommands.ConsoleSystem
                             File.WriteAllText(GlobalVariables.currentDirectory, pathSeparator);
                             return;
                         }
-                        Console.WriteLine($"Directory '{s_newLocation}'\\ dose not exist!");
+                        Console.WriteLine($"Directory '{s_newLocation}'\\ does not exist!");
                     }
                     else if (s_newLocation == "..")
                     {
@@ -84,7 +84,7 @@ namespace Commands.TerminalCommands.ConsoleSystem
                             File.WriteAllText(GlobalVariables.currentDirectory, pathSeparator);
                             return;
                         }
-                        Console.WriteLine($"Directory '{pathCombine}' dose not exist!");
+                        Console.WriteLine($"Directory '{pathCombine}' does not exist!");
                     }
                     return;
                 }

--- a/Commands/TerminalCommands/ConsoleSystem/Help.cs
+++ b/Commands/TerminalCommands/ConsoleSystem/Help.cs
@@ -30,21 +30,21 @@ This is the full list of commands that can be used in xTerminal:
     odir      -- Open current directory or other directory path provided with Windows Explorer.
     ps        -- Opens Windows Powershell.
     cmd       -- Opens Windows Command Prompt.
-    reboot    -- It force reboots the Windows OS.
-    shutdown  -- It force shutdown the Windows OS.
-    logoff    -- It force logoff current user.
-    lock      -- Locks the screen(similar to Win+L key combination).
+    reboot    -- Forces reboot of the Windows OS.
+    shutdown  -- Forces shutdown of the Windows OS.
+    logoff    -- Forces logoff of the current user.
+    lock      -- Locks the screen (similar to Win+L key combination).
     bios      -- Displays BIOS information on local machine or remote. Use -h for additional parameters.
     sinfo     -- Displays Storage devices information on local machine or remote. Use -h for additional parameters.
-    hex       -- Display a hex dump of a file. Use -h for additional parameters.
-    pcinfo    -- Display System Information.
+    hex       -- Displays a hex dump of a file. Use -h for additional parameters.
+    pcinfo    -- Displays System Information.
     nt        -- Starts new xTerminal console.
                  -u : Starts new xTerminal console with other user option.
 
     ---------------------- File System ---------------------
     cat       -- Displays the content of a file. Use -h for additional parameters.
-    mkdir     -- It creates a directory in the current place.
-    mkfile    -- It creates a file in the current place.
+    mkdir     -- Creates a directory in the current place.
+    mkfile    -- Ccreates a file in the current place.
     fcopy     -- Copies a file with CRC checksum control.  Use -h for additional parameters.
     frename   -- Renames a file in a specific directory(s).
                  Example: frename <old_file_name> -o <new_file_name>
@@ -66,7 +66,7 @@ This is the full list of commands that can be used in xTerminal:
     extip     -- Displays the current external IP address.
     wget      -- Download files from a specific website. Use -h for additional help.
     email     -- Email sender client for Microsoft (all), Yahoo, Gmail!
-    ping      -- Pings a IP/Hostname.  Use -h for additional parameters.
+    ping      -- Pings a IP/Hostname. Use -h for additional parameters.
     cport     -- Checks if a specific port is open/closed on a Hostname/IP.  Use -h for additional parameters.
 
     -----------------C# Core Runner and Add-ons -------------

--- a/Commands/TerminalCommands/ConsoleSystem/Help.cs
+++ b/Commands/TerminalCommands/ConsoleSystem/Help.cs
@@ -44,7 +44,7 @@ This is the full list of commands that can be used in xTerminal:
     ---------------------- File System ---------------------
     cat       -- Displays the content of a file. Use -h for additional parameters.
     mkdir     -- Creates a directory in the current place.
-    mkfile    -- Ccreates a file in the current place.
+    mkfile    -- Creates a file in the current place.
     fcopy     -- Copies a file with CRC checksum control.  Use -h for additional parameters.
     frename   -- Renames a file in a specific directory(s).
                  Example: frename <old_file_name> -o <new_file_name>

--- a/Commands/TerminalCommands/ConsoleSystem/ListDirectories.cs
+++ b/Commands/TerminalCommands/ConsoleSystem/ListDirectories.cs
@@ -40,13 +40,13 @@ namespace Commands.TerminalCommands.ConsoleSystem
 
         private static string s_helpMessage = @"Usage of ls command:
     -h  : Displays this message.
-    -d  : Display duplicate files in a directory and subdirectories.
+    -d  : Displays duplicate files in a directory and subdirectories.
           Example1: ls -d <directory_path>
           Example2: ls -d -e <directory_path> (scans for duplicate files with same extension)
           Example3: ls -d <directory_path> -o <file_to_save>
           Example4: ls -d -e <directory_path> -o <file_to_save>  (scans for duplicate files with same extension)
     -s  : Displays size of files in current directory and subdirectories.
-    -se : List recursively files and directories containing a specific text.
+    -se : Recursively lists files and directories containing a specific text.
           Example1: ls -se <search_text>
           Example2: ls -se <search_text> -o <file_to_save>
     -c  : Counts files and directories and subdirectories from current directory.
@@ -54,7 +54,7 @@ namespace Commands.TerminalCommands.ConsoleSystem
           Example: ls -cf <search_text>
     -cd : Counts directories from current directory and subdirectories with name containing a specific text.
           Example: ls -cd <search_text>
-    -ct : Display creation date time of files and folders from current directory.
+    -ct : Displays creation date time of files and folders from current directory.
     -hl : Highlights specific files/directories with by a specific text. Ex.: ls -hl <higlighted_text>
     -o  : Saves the output to a file. Ex.: ls -o <file_to_save>
 
@@ -207,7 +207,7 @@ Commands can be canceled with CTRL+X key combination.
 
                 if (arg.ContainsParameter("-c"))
                 {
-                    Console.WriteLine($"\nCounting total directories/subdirectories and files on current location....\n");
+                    Console.WriteLine($"\nCounting total directories/subdirectories and files on current location...\n");
                     GlobalVariables.eventKeyFlagX = true;
                     DisplaySubDirectoryAndFileCounts(s_currentDirectory, string.Empty, string.Empty, false);
                     Console.WriteLine($"Total directories/subdirectories: {s_countDirectories}");
@@ -224,7 +224,7 @@ Commands can be canceled with CTRL+X key combination.
                     {
                         GlobalVariables.eventKeyFlagX = true;
                         DisplaySubDirectoryAndFileCounts(s_currentDirectory, arg.ParameterAfter("-cf"), "", false);
-                        Console.WriteLine($"Total files count that contains '{arg.ParameterAfter("-cf")}' (from subdirectories too): {s_countFilesText}\n");
+                        Console.WriteLine($"Total files count that contains '{arg.ParameterAfter("-cf")}' (including subdirectories): {s_countFilesText}\n");
                         if (GlobalVariables.eventCancelKey)
                             FileSystem.ColorConsoleTextLine(ConsoleColor.Yellow, "Command stopped!");
                         ClearCounters();
@@ -264,7 +264,7 @@ Commands can be canceled with CTRL+X key combination.
             }
             catch (IndexOutOfRangeException)
             {
-                FileSystem.ErrorWriteLine("The command parameters were not valid");
+                FileSystem.ErrorWriteLine("The command parameters were invalid!");
             }
             catch (UnauthorizedAccessException)
             {

--- a/Commands/TerminalCommands/ConsoleSystem/PCInfo.cs
+++ b/Commands/TerminalCommands/ConsoleSystem/PCInfo.cs
@@ -148,8 +148,8 @@ namespace Commands.TerminalCommands.ConsoleSystem
             DriveInfo[] allDrives = DriveInfo.GetDrives();
             foreach (var d in allDrives)
             {
-                string totalSize = wmi.SizeConvert("Size "+d.TotalSize.ToString(),true);
-                string availableSize = wmi.SizeConvert("Size " + d.AvailableFreeSpace.ToString(),true);
+                string totalSize = wmi.SizeConvert($"Size {d.TotalSize}", true);
+                string availableSize = wmi.SizeConvert($"Size {d.AvailableFreeSpace}", true);
                 FileSystem.ColorConsoleText(ConsoleColor.Green, $"{d.Name}: ");
                 Console.Write($" Free: {availableSize} / Total: {totalSize} / Type: {d.DriveType} \n");
             }

--- a/Commands/TerminalCommands/ConsoleSystem/StartProccess.cs
+++ b/Commands/TerminalCommands/ConsoleSystem/StartProccess.cs
@@ -11,8 +11,8 @@ namespace Commands.TerminalCommands.ConsoleSystem
         private static string s_currentDirectory = string.Empty;
         public string Name => "start";
         private string _helpMessage = @"Usage: start <file_name> OR start <file_name> -p <file_paramters>
-Can use with following parameter:
-    -h : Display this message.
+Can be used with the following parameters:
+    -h : Displays this message.
     -u : Can run process with different user.
          Example1: start -u <file_name>
          Example2: start -u <file_name> -p <file_paramters>

--- a/Commands/TerminalCommands/DirFiles/Delete.cs
+++ b/Commands/TerminalCommands/DirFiles/Delete.cs
@@ -10,9 +10,9 @@ namespace Commands.TerminalCommands.DirFiles
         private string _currentLocation;
         private string _helpMessage = @"Usage of del command:
     -h  : Displays this message. 
-    -a  : Deletes all files and directories in current directory. 
-    -af : Deletes all files in current directory. 
-    -ad : Deletes all directories in current directory. 
+    -a  : Deletes all files and directories in the current directory. 
+    -af : Deletes all files in the current directory. 
+    -ad : Deletes all directories in the current directory. 
 ";
 
         public void Execute(string args)
@@ -78,27 +78,27 @@ namespace Commands.TerminalCommands.DirFiles
         {
             try
             {
-                string input = arg;              // geting location input        
+                string input = arg; // Geting location input        
 
-                //checking the cureent locaiton in folder
+                // Checking the current locaiton in folder
                 if (input.Contains(":") && input.Contains(@"\"))
                 {
                     try
                     {
-                        // get the file attributes for file or directory
+                        // Get the file attributes for file or directory
                         FileAttributes attr = File.GetAttributes(input);
 
                         if (attr.HasFlag(FileAttributes.Directory))
                         {
                             var dir = new DirectoryInfo(input);
                             RecursiveDeleteDir(dir);
-                            Console.WriteLine("Directory " + input + " deleted!");
+                            Console.WriteLine($"Directory {input} deleted!");
                         }
                         else
                         {
                             File.SetAttributes(input, FileAttributes.Normal);
                             File.Delete(input);
-                            Console.WriteLine("File " + input + " deleted!");
+                            Console.WriteLine($"File {input} deleted!");
                         }
                     }
                     catch (Exception e)
@@ -110,7 +110,7 @@ namespace Commands.TerminalCommands.DirFiles
                 {
                     try
                     {
-                        // get the file attributes for file or directory
+                        // Get the file attributes for file or directory
                         FileAttributes attr = File.GetAttributes(currentLocation + input);
 
                         if (attr.HasFlag(FileAttributes.Directory))
@@ -146,7 +146,7 @@ namespace Commands.TerminalCommands.DirFiles
         {
             if (!directory.Exists)
             {
-                FileSystem.ErrorWriteLine("Directory '{directory}' does not exist!");
+                FileSystem.ErrorWriteLine($"Directory '{directory}' does not exist!");
                 return;
             }
 

--- a/Commands/TerminalCommands/DirFiles/Difference.cs
+++ b/Commands/TerminalCommands/DirFiles/Difference.cs
@@ -107,7 +107,7 @@ namespace Commands.TerminalCommands.DirFiles
                                     Console.Write("- ");
                                     break;
                                 default:
-                                    Console.ForegroundColor = ConsoleColor.Gray; // compromise for dark or light background
+                                    Console.ForegroundColor = ConsoleColor.Gray; // Compromise for dark or light background
                                     Console.Write("  ");
                                     break;
                             }
@@ -163,7 +163,7 @@ namespace Commands.TerminalCommands.DirFiles
                     }
                     return;
                 }
-                FileSystem.ColorConsoleTextLine(ConsoleColor.Yellow, "Only 2 files can be compared!");
+                FileSystem.ColorConsoleTextLine(ConsoleColor.Yellow, "Only two files can be compared!");
             }
             catch (Exception e)
             {

--- a/Commands/TerminalCommands/DirFiles/Editor.cs
+++ b/Commands/TerminalCommands/DirFiles/Editor.cs
@@ -38,7 +38,7 @@ namespace Commands.TerminalCommands.DirFiles
                     Console.WriteLine("Your New editor is: " + set);
                     return;
                 }
-                FileSystem.ErrorWriteLine($"File {set} dose not exist");
+                FileSystem.ErrorWriteLine($"File {set} does not exist!");
                 return;
             }
             catch
@@ -46,7 +46,7 @@ namespace Commands.TerminalCommands.DirFiles
                 file = FileSystem.SanitizePath(file, dlocation);
                 if (string.IsNullOrEmpty(file))
                 {
-                    Console.WriteLine("You must type the file name for edit!");
+                    Console.WriteLine("You must type name of the file to be edited!");
                     return;
                 }
                 ProcessCall(file, File.Exists(cEditor) ? cEditor : "notepad");

--- a/Commands/TerminalCommands/DirFiles/FCopy.cs
+++ b/Commands/TerminalCommands/DirFiles/FCopy.cs
@@ -67,10 +67,10 @@ namespace Commands.TerminalCommands.DirFiles
                 if (arg == $"{Name} -h")
                 {
                     Console.WriteLine(@"Usage of fcopy command:
-    fcopy <source_file> -o <destination_file>. Can bee used with following parameters:
-    fcopy -h : displays this message    
-    fcopy -ca <destination_directory> : copy all files from current directory in a specific directory
-    fcopy -ca : copy source files in same directory
+    fcopy <source_file> -o <destination_file>. Can be used with the following parameters:
+    fcopy -h : Displays this message
+    fcopy -ca <destination_directory> : Copies all files from the current directory to a specific directory
+    fcopy -ca : Copies source files in the same directory
 ");
                     return;
                 }
@@ -92,10 +92,10 @@ namespace Commands.TerminalCommands.DirFiles
                                 int woIndex = 0;
                                 int wIndex = 0;
                                 int countF = Regex.Matches(file, @"\\").Count;
-                                //we get the file name
+                                // We get the file name
                                 string delilmiterSplitF = file.Split('\\')[countF];
 
-                                //we check if file is already indexed or not
+                                // We check if file is already indexed or not
                                 if (delilmiterSplitF.StartsWith("(") && delilmiterSplitF.Contains(") - "))
                                 {
                                     string fileNameSplit2 = delilmiterSplitF.Split(')')[1];
@@ -124,7 +124,7 @@ namespace Commands.TerminalCommands.DirFiles
                                     }
                                     else
                                     {
-                                        Console.WriteLine($"Source file '{Source}' dose not exist!" + Environment.NewLine);
+                                        Console.WriteLine($"Source file '{Source}' does not exist!" + Environment.NewLine);
                                     }
                                 }
 
@@ -140,7 +140,7 @@ namespace Commands.TerminalCommands.DirFiles
                                 }
 
 
-                                //copy module
+                                // Copy module
                                 if (File.Exists(Source))
                                 {
                                     if (!File.Exists(Destination))
@@ -202,11 +202,11 @@ namespace Commands.TerminalCommands.DirFiles
                                 }
                                 else
                                 {
-                                    Console.WriteLine($"Source file '{Source}' dose not exist!" + Environment.NewLine);
+                                    Console.WriteLine($"Source file '{Source}' does not exist!" + Environment.NewLine);
                                 }
                                 //-------------------------
 
-                                //Grabing destination file crc
+                                // Grabing destination file crc
                                 using (var crc32 = Crc32.Create())
                                 {
                                     using (var stream = File.OpenRead(Destination))
@@ -227,7 +227,7 @@ namespace Commands.TerminalCommands.DirFiles
                                 else
                                 {
                                     File.Delete(Destination);
-                                    FileSystem.ColorConsoleTextLine(ConsoleColor.Red, "CRC dose not match! File was not copied." + Environment.NewLine);
+                                    FileSystem.ColorConsoleTextLine(ConsoleColor.Red, "CRC does not match! File was not copied." + Environment.NewLine);
                                     FilesErrorCopy.Add(Source);
                                 }
                             }
@@ -244,10 +244,10 @@ namespace Commands.TerminalCommands.DirFiles
                                 int woIndex = 0;
                                 int wIndex = 0;
                                 int countF = Regex.Matches(file, @"\\").Count;
-                                //we get the file name
+                                // We get the file name
                                 string delilmiterSplitF = file.Split('\\')[countF];
 
-                                //we check if file is already indexed or not
+                                // We check if file is already indexed or not
                                 if (delilmiterSplitF.StartsWith("(") && delilmiterSplitF.Contains(") - "))
                                 {
                                     string fileNameSplit2 = delilmiterSplitF.Split(')')[1];
@@ -262,7 +262,7 @@ namespace Commands.TerminalCommands.DirFiles
                                 FileCount--;
                                 Source = file;
 
-                                //check if source is current path
+                                // Check if source is current path
                                 if (!Source.Contains(":") || !Source.Contains(@"\"))
                                 {
                                     Source = dlocation + Source;
@@ -282,7 +282,7 @@ namespace Commands.TerminalCommands.DirFiles
                                     }
                                     else
                                     {
-                                        Console.WriteLine($"Source file '{Source}' dose not exist!" + Environment.NewLine);
+                                        Console.WriteLine($"Source file '{Source}' does not exist!" + Environment.NewLine);
                                     }
                                 }
 
@@ -298,7 +298,7 @@ namespace Commands.TerminalCommands.DirFiles
                                 }
 
 
-                                //copy module
+                                // Copy module
                                 if (File.Exists(Source))
                                 {
                                     if (!File.Exists(Destination))
@@ -363,11 +363,11 @@ namespace Commands.TerminalCommands.DirFiles
                                 }
                                 else
                                 {
-                                    Console.WriteLine($"Source file '{Source}' dose not exist!" + Environment.NewLine);
+                                    Console.WriteLine($"Source file '{Source}' does not exist!" + Environment.NewLine);
                                 }
                                 //-------------------------
 
-                                //Grabing destination file crc
+                                // Grabing destination file crc
                                 using (var crc32 = Crc32.Create())
                                 {
                                     using (var stream = File.OpenRead(Destination))
@@ -388,7 +388,7 @@ namespace Commands.TerminalCommands.DirFiles
                                 else
                                 {
                                     File.Delete(Destination);
-                                    FileSystem.ColorConsoleTextLine(ConsoleColor.Red, "CRC dose not match! File was not copied." + Environment.NewLine);
+                                    FileSystem.ColorConsoleTextLine(ConsoleColor.Red, "CRC does not match! File was not copied." + Environment.NewLine);
                                     FilesErrorCopy.Add(Source);
                                 }
                             }
@@ -415,7 +415,7 @@ namespace Commands.TerminalCommands.DirFiles
                         }
                         else
                         {
-                            Console.WriteLine($"Source file '{Source}' dose not exist!" + Environment.NewLine);
+                            Console.WriteLine($"Source file '{Source}' does not exist!" + Environment.NewLine);
                         }
                     }
 
@@ -426,7 +426,7 @@ namespace Commands.TerminalCommands.DirFiles
                         Destination = dlocation + Destination;
                     }
 
-                    //copy module
+                    // Copy module
                     if (File.Exists(Source))
                     {
                         if (!File.Exists(Destination))
@@ -435,12 +435,12 @@ namespace Commands.TerminalCommands.DirFiles
                         }
                         else
                         {
-                            Console.WriteLine($"Destination file '{Destination}' already exist!" + Environment.NewLine);
+                            Console.WriteLine($"Destination file '{Destination}' already exists!" + Environment.NewLine);
                         }
                     }
                     else
                     {
-                        Console.WriteLine($"Source file '{Source}' dose not exist!" + Environment.NewLine);
+                        Console.WriteLine($"Source file '{Source}' does not exist!" + Environment.NewLine);
                     }
                     //-------------------------
                     //Grabing destination file crc
@@ -461,7 +461,7 @@ namespace Commands.TerminalCommands.DirFiles
                     else
                     {
                         File.Delete(Destination);
-                        FileSystem.ColorConsoleTextLine(ConsoleColor.Red, "CRC dose not match! File was not copied." + Environment.NewLine);
+                        FileSystem.ColorConsoleTextLine(ConsoleColor.Red, "CRC does not match! File was not copied." + Environment.NewLine);
                         FilesErrorCopy.Add(Source);
                     }
                 }

--- a/Commands/TerminalCommands/DirFiles/FMove.cs
+++ b/Commands/TerminalCommands/DirFiles/FMove.cs
@@ -68,13 +68,13 @@ namespace Commands.TerminalCommands.DirFiles
                 if (arg == $"{Name} -h")
                 {
                     Console.WriteLine(@"Usage of fmove command:
-    fmove <source_file> -o <destination_file>. Can bee used with following parameters:
-    fmove -ma <destination_directory> : moves all files from current directory in a specific directory
+    fmove <source_file> -o <destination_file>. Can be used with the following parameters:
+    fmove -ma <destination_directory> : Moves all files from the current directory in a specific directory
 ");
                     return;
                 }
 
-                //Move all with and without args
+                // Move all with and without args
                 if (arg.Contains(" -ma "))
                 {
                     dfiles = Directory.GetFiles(NewPath);
@@ -92,10 +92,10 @@ namespace Commands.TerminalCommands.DirFiles
                                 int woIndex = 0;
                                 int wIndex = 0;
                                 int countF = Regex.Matches(file, @"\\").Count;
-                                //we get the file name
+                                // We get the file name
                                 string delilmiterSplitF = file.Split('\\')[countF];
 
-                                //we check if file is already indexed or not
+                                // We check if file is already indexed or not
                                 if (delilmiterSplitF.StartsWith("(") && delilmiterSplitF.Contains(") - "))
                                 {
                                     string fileNameSplit2 = delilmiterSplitF.Split(')')[1];
@@ -127,7 +127,7 @@ namespace Commands.TerminalCommands.DirFiles
                                     }
                                     else
                                     {
-                                        Console.WriteLine($"Source file '{Source}' dose not exist!" + Environment.NewLine);
+                                        Console.WriteLine($"Source file '{Source}' does not exist!" + Environment.NewLine);
                                     }
                                 }
 
@@ -205,7 +205,7 @@ namespace Commands.TerminalCommands.DirFiles
                                 }
                                 else
                                 {
-                                    Console.WriteLine($"Source file '{Source}' dose not exist!" + Environment.NewLine);
+                                    Console.WriteLine($"Source file '{Source}' does not exist!" + Environment.NewLine);
                                 }
                                 //-------------------------
 
@@ -231,7 +231,7 @@ namespace Commands.TerminalCommands.DirFiles
                                 else
                                 {
                                     File.Delete(Destination);
-                                    FileSystem.ColorConsoleTextLine(ConsoleColor.Red, "CRC dose not match! File was not moved." + Environment.NewLine);
+                                    FileSystem.ColorConsoleTextLine(ConsoleColor.Red, "CRC does not match! File was not moved." + Environment.NewLine);
                                     FilesErrorCopy.Add(Source);
                                 }
                             }
@@ -247,10 +247,10 @@ namespace Commands.TerminalCommands.DirFiles
                                 int woIndex = 0;
                                 int wIndex = 0;
                                 int countF = Regex.Matches(file, @"\\").Count;
-                                //we get the file name
+                                // We get the file name
                                 string delilmiterSplitF = file.Split('\\')[countF];
 
-                                //we check if file is already indexed or not
+                                // We check if file is already indexed or not
                                 if (delilmiterSplitF.StartsWith("(") && delilmiterSplitF.Contains(") - "))
                                 {
                                     string fileNameSplit2 = delilmiterSplitF.Split(')')[1];
@@ -265,7 +265,7 @@ namespace Commands.TerminalCommands.DirFiles
                                 FileCount--;
                                 Source = file;
 
-                                //check if source is current path
+                                // Check if source is current path
                                 if (!Source.Contains(":") || !Source.Contains(@"\"))
                                 {
                                     Source = dlocation + Source;
@@ -285,7 +285,7 @@ namespace Commands.TerminalCommands.DirFiles
                                     }
                                     else
                                     {
-                                        Console.WriteLine($"Source file '{Source}' dose not exist!" + Environment.NewLine);
+                                        Console.WriteLine($"Source file '{Source}' does not exist!" + Environment.NewLine);
                                     }
                                 }
 
@@ -301,7 +301,7 @@ namespace Commands.TerminalCommands.DirFiles
                                 }
 
 
-                                //copy module
+                                // Copy module
                                 if (File.Exists(Source))
                                 {
                                     if (!File.Exists(Destination))
@@ -366,7 +366,7 @@ namespace Commands.TerminalCommands.DirFiles
                                 }
                                 else
                                 {
-                                    Console.WriteLine($"Source file '{Source}' dose not exist!" + Environment.NewLine);
+                                    Console.WriteLine($"Source file '{Source}' does not exist!" + Environment.NewLine);
                                 }
                                 //-------------------------
 
@@ -392,7 +392,7 @@ namespace Commands.TerminalCommands.DirFiles
                                 else
                                 {
                                     File.Delete(Destination);
-                                    FileSystem.ColorConsoleTextLine(ConsoleColor.Red, "CRC dose not match! File was not moved." + Environment.NewLine);
+                                    FileSystem.ColorConsoleTextLine(ConsoleColor.Red, "CRC does not match! File was not moved." + Environment.NewLine);
                                     FilesErrorCopy.Add(Source);
                                 }
                             }
@@ -420,7 +420,7 @@ namespace Commands.TerminalCommands.DirFiles
                         }
                         else
                         {
-                            Console.WriteLine($"Source file '{Source}' dose not exist!" + Environment.NewLine);
+                            Console.WriteLine($"Source file '{Source}' does not exist!" + Environment.NewLine);
                         }
                     }
 
@@ -431,7 +431,7 @@ namespace Commands.TerminalCommands.DirFiles
                         Destination = dlocation + Destination;
                     }
 
-                    //copy module
+                    // Copy module
                     if (File.Exists(Source))
                     {
                         if (!File.Exists(Destination))
@@ -440,12 +440,12 @@ namespace Commands.TerminalCommands.DirFiles
                         }
                         else
                         {
-                            Console.WriteLine($"Destination file '{Destination}' already exist!" + Environment.NewLine);
+                            Console.WriteLine($"Destination file '{Destination}' already exists!" + Environment.NewLine);
                         }
                     }
                     else
                     {
-                        Console.WriteLine($"Source file '{Source}' dose not exist!" + Environment.NewLine);
+                        Console.WriteLine($"Source file '{Source}' does not exist!" + Environment.NewLine);
                     }
                     //-------------------------
                     //Grabing destination file crc
@@ -468,7 +468,7 @@ namespace Commands.TerminalCommands.DirFiles
                     else
                     {
                         File.Delete(Destination);
-                        FileSystem.ColorConsoleTextLine(ConsoleColor.Red, "CRC dose not match! File was not moved." + Environment.NewLine);
+                        FileSystem.ColorConsoleTextLine(ConsoleColor.Red, "CRC does not match! File was not moved." + Environment.NewLine);
                         FilesErrorCopy.Add(Source);
                     }
                 }
@@ -481,7 +481,7 @@ namespace Commands.TerminalCommands.DirFiles
             {
                 if (x.ToString().Contains("is being used by another process"))
                 {
-                    FileSystem.ErrorWriteLine("File '" + Destination + "' is being used by another process. Terminated!");
+                    FileSystem.ErrorWriteLine($"File '{Destination}' is being used by another process. Terminated!");
                 }
                 else
                 {

--- a/Commands/TerminalCommands/DirFiles/FRename.cs
+++ b/Commands/TerminalCommands/DirFiles/FRename.cs
@@ -17,22 +17,22 @@ namespace Commands.TerminalCommands.DirFiles
             {
                 arg = arg.Replace("frename ", "");
 
-                //reading current location(for test no, after i make dynamic)
+                // Reading current location(for test no, after i make dynamic)
                 string dlocation = File.ReadAllText(GlobalVariables.currentDirectory); ;
                 string cLocation = Directory.GetCurrentDirectory();
 
-                //we grab the file names for source and destination
+                // We grab the file names for source and destination
                 string FileName = FileSystem.SanitizePath(arg.SplitByText(" -o ", 0), dlocation);
                 string NewName = FileSystem.SanitizePath(arg.SplitByText(" -o ", 1), dlocation);
 
-                //we check if file exists
+                // We check if file exists
                 if (File.Exists(FileName))
                 {
                     File.Move(FileName, NewName);
                     Console.WriteLine($"File renamed from {FileName} to {NewName}");
                     return;
                 }
-                FileSystem.ErrorWriteLine("File " + FileName + " dose not exist!");
+                FileSystem.ErrorWriteLine("File " + FileName + " does not exist!");
             }
             catch
             {

--- a/Commands/TerminalCommands/DirFiles/Locate.cs
+++ b/Commands/TerminalCommands/DirFiles/Locate.cs
@@ -14,10 +14,10 @@ namespace Commands.TerminalCommands.DirFiles
         private string _currentLocation;
         private static string s_helpMessage = @"Usage of locate command:
 
-    Example 1: locate <text> (Displays searched files/directories from current directory and subdirectories that includes a specific text.)
+    Example 1: locate <text> (Displays searched files/directories from the current directory and subdirectories that includes a specific text.)
     Example 2: locate <text> -o <save_to_file> (Stores in to a file the searched files/directories from current directory and subdirectories that includes a specific text.)
   
-Command be canceled with CTRL+X key combination.
+Command can be canceled with CTRL+X key combination.
 ";
 
         public void Execute(string arg)

--- a/Commands/TerminalCommands/DirFiles/MD5Check.cs
+++ b/Commands/TerminalCommands/DirFiles/MD5Check.cs
@@ -15,8 +15,8 @@ namespace Commands.TerminalCommands.DirFiles
         public string Name => "md5";
         private static string s_currentDirectory;
         private static string s_helpMessage = @"Usage of MD5 command:
- md5 <file_name> : Display the MD5 CheckSUM of a file.
- md5 -d <dire_name> : Display the MD5 CheckSUM list of all the files in a directory and subdirectories.
+ md5 <file_name> : Displays the MD5 CheckSUM of a file.
+ md5 -d <dire_name> : Displays the MD5 CheckSUM list of all the files in a directory and subdirectories.
  md5 -d <dire_name> -o <save_to_file> : Saves the MD5 CheckSUM list of all the files in a directory and subdirectories.
 
 Command md5 -d can be canceled with CTRL+X key combination.
@@ -139,7 +139,7 @@ Command md5 -d can be canceled with CTRL+X key combination.
                     else
                     {
                         if (fileCheck)
-                            retValue = "File " + arg + " dose not exist!";
+                            retValue = $"File {arg} does not exist!";
                     }
                 }
                 else
@@ -158,7 +158,7 @@ Command md5 -d can be canceled with CTRL+X key combination.
                     else
                     {
                         if (fileCheck)
-                            retValue += "File " + cDir + @"\" + arg + " dose not exist!";
+                            retValue += $"File {cDir}\\{arg} does not exist!";
                     }
                 }
                 return retValue;

--- a/Commands/TerminalCommands/DirFiles/MakeDirectory.cs
+++ b/Commands/TerminalCommands/DirFiles/MakeDirectory.cs
@@ -14,14 +14,14 @@ namespace Commands.TerminalCommands.DirFiles
                 int argLength = arg.Length - 6;
 
                 string input = arg.Substring(6, argLength);
-                string newlocation = File.ReadAllText(GlobalVariables.currentDirectory); ; //get the new location
-                string locinput = newlocation + input; //new location+input
+                string newlocation = File.ReadAllText(GlobalVariables.currentDirectory); ; // Get the new location
+                string locinput = newlocation + input; // New location+input
                 if (input.Contains(":") && input.Contains(@"\"))
                 {
                     try
                     {
                         Directory.CreateDirectory(input);
-                        Console.WriteLine("Directory " + input + " is created!");
+                        Console.WriteLine($"Directory {input} is created!");
                     }
                     catch (Exception)
                     {
@@ -33,7 +33,7 @@ namespace Commands.TerminalCommands.DirFiles
                     try
                     {
                         Directory.CreateDirectory(locinput);
-                        Console.WriteLine("Directory " + locinput + " is created!");
+                        Console.WriteLine($"Directory {locinput} is created!");
                     }
                     catch (Exception)
                     {

--- a/Commands/TerminalCommands/DirFiles/SortData.cs
+++ b/Commands/TerminalCommands/DirFiles/SortData.cs
@@ -12,12 +12,12 @@ namespace Commands.TerminalCommands.DirFiles
         private string _currentDirectory;
         private string _helpMessage = @"Usage of sort command:
 
-    Example 1: sort -a filePath  (Sort data ascending and displays it.)
-    Example 2: sort -a filePath -o saveFilePath  (Sort data ascending and saves it to a file.)
-    Example 3: sort -d filePath  (Sort data descending and displays it.)
-    Example 4: sort -d filePath -o saveFilePath  (Sort data descending and saves it to a file.)
+    Example 1: sort -a filePath  (Sorts data in ascending order and displays it.)
+    Example 2: sort -a filePath -o saveFilePath  (Sorts data in ascending order and saves it to a file.)
+    Example 3: sort -d filePath  (Sorts data in descending order and displays it.)
+    Example 4: sort -d filePath -o saveFilePath  (Sorts data in descending order and saves it to a file.)
 
-Command running without saveing to file can be canceled with CTRL+X key combination.
+Command running without saving to file can be canceled with CTRL+X key combination.
 ";
 
         public void Execute(string arg)

--- a/Commands/TerminalCommands/DirFiles/StringView.cs
+++ b/Commands/TerminalCommands/DirFiles/StringView.cs
@@ -20,7 +20,7 @@ namespace Commands.TerminalCommands.DirFiles
            Example: cat -n 10 <path_of_file_name>
   -l   : Displays data between two lines range.
            Example: cat -l 10-20 <path_of_file_name>
-  -s   : Output lines containing a provided text from a file.
+  -s   : Outputs lines containing a provided text from a file.
            Example: cat -s <search_text> -f <file_search_in>
   -so  : Saves the lines containing a provided text from a file.
            Example: cat -so <search_text> -f <file_search_in> -o <file_to_save>
@@ -37,7 +37,7 @@ namespace Commands.TerminalCommands.DirFiles
   -lc  : Counts all the lines(without empty lines) in all files on current directory and subdirectories.
   -lfc : Counts all the lines(without empty lines) that contains a specific text in file name in current directory and subdirectories.
            Example: cat -lfc <file_name_text>
-  -con : Concatenate text files to a single file.
+  -con : Concatenates text files to a single file.
            Example: cat -con file1;file2;file3 -o fileOut
 
 Commands can be canceled with CTRL+X key combination.
@@ -107,13 +107,13 @@ Commands can be canceled with CTRL+X key combination.
                         if (outFileData.Length > 0)
                             Console.WriteLine($"Data was saved to: {outputFile}");
                         else
-                            Console.WriteLine("No file ware concatenated!");
+                            Console.WriteLine("No files were concatenated!");
                         break;
                     case "-n":
                         string lineCounter = arg.Split(' ')[1];
                         if (!FileSystem.IsNumberAllowed(lineCounter))
                         {
-                            FileSystem.ErrorWriteLine("Parameter invalid. You need to provide how many lines you want to display!");
+                            FileSystem.ErrorWriteLine("Invalid parameter. You need to provide how many lines you want to display!");
                             return;
                         }
                         int lines = Int32.Parse(lineCounter);
@@ -128,7 +128,7 @@ Commands can be canceled with CTRL+X key combination.
                         string linesRange = arg.Split(' ')[1];
                         if (!linesRange.Contains("-"))
                         {
-                            FileSystem.ErrorWriteLine("Parameter invalid. You need to provide the range of lines for data display! Example: 10-20");
+                            FileSystem.ErrorWriteLine("Invalid parameter. You need to provide the range of lines for data display! Example: 10-20");
                             return;
                         }
                         string pathFile = FileSystem.SanitizePath(arg.SplitByText(linesRange + " ", 1), s_currentDirectory);
@@ -169,7 +169,7 @@ Commands can be canceled with CTRL+X key combination.
                             GlobalVariables.eventKeyFlagX = true;
                             s_output = Core.Commands.CatCommand.MultiFileOutput(searchString, s_currentDirectory, fileName.Split(' '), "", true);
                         }
-                        s_output = string.IsNullOrWhiteSpace(s_output) ? "No files with names that contains that text!" : s_output;
+                        s_output = string.IsNullOrWhiteSpace(s_output) ? "No file names contain that text!" : s_output;
                         Console.WriteLine(s_output);
                         if (GlobalVariables.eventCancelKey)
                             FileSystem.ColorConsoleTextLine(ConsoleColor.Yellow, "Command stopped!");
@@ -207,7 +207,7 @@ Commands can be canceled with CTRL+X key combination.
 
                         if (string.IsNullOrWhiteSpace(s_output))
                         {
-                            Console.WriteLine("No files with names that contains that text!");
+                            Console.WriteLine("No file names contain that text!");
                         }
                         else
                         {

--- a/Commands/TerminalCommands/Games/FlappyBirds.cs
+++ b/Commands/TerminalCommands/Games/FlappyBirds.cs
@@ -175,7 +175,7 @@ namespace Commands.TerminalCommands.Games
             Console.ForegroundColor = ConsoleColor.Yellow;
             Console.WriteLine();
             Console.WriteLine("||---------------------- FLAPPY BIRD ---------------------||");
-            Console.WriteLine("                    ** Console verion **");
+            Console.WriteLine("                    ** Console version **");
             Console.WriteLine("                        <<< HELP >>>");
             Console.WriteLine();
             Console.ForegroundColor = ConsoleColor.Cyan;
@@ -198,7 +198,7 @@ namespace Commands.TerminalCommands.Games
             Console.ForegroundColor = ConsoleColor.Yellow;
             Console.WriteLine();
             Console.WriteLine("||---------------------- FLAPPY BIRD ---------------------||");
-            Console.WriteLine("                    ** Console verion **");
+            Console.WriteLine("                    ** Console version **");
             Console.WriteLine("                      <<< CREDITS >>>");
             Console.WriteLine();
             Console.WriteLine();
@@ -225,14 +225,14 @@ namespace Commands.TerminalCommands.Games
             Console.ForegroundColor = ConsoleColor.Yellow;
             Console.WriteLine();
             Console.WriteLine("||---------------------- FLAPPY BIRD ---------------------||");
-            Console.WriteLine("                    ** Console verion **");
+            Console.WriteLine("                    ** Console version **");
             Console.WriteLine("                        <<< HELPS >>>");
             Console.WriteLine();
             Console.WriteLine();
             Console.WriteLine();
             Console.ForegroundColor = ConsoleColor.White;
-            Console.WriteLine("         Keep the bird flying and avoiding the pipes");
-            Console.WriteLine("     Don't let him touch the ground or the top of window");
+            Console.WriteLine("           Keep the bird flying and avoid the pipes");
+            Console.WriteLine("     Don't let him touch the ground or the top of the window");
             Console.WriteLine();
             Console.WriteLine("    Keyboard buttons: - Press Spacebar to raise the bird");
             Console.WriteLine("                      - Press R to restart game");

--- a/Commands/TerminalCommands/Games/Snake.cs
+++ b/Commands/TerminalCommands/Games/Snake.cs
@@ -99,7 +99,7 @@ namespace Commands.TerminalCommands.Games
                     }
                 }
             }
-            Console.WriteLine($"Game Over Score:{_score}");
+            Console.WriteLine($"Game Over Score: {_score}");
             return;
         }
 
@@ -142,7 +142,7 @@ namespace Commands.TerminalCommands.Games
                         throw new ArgumentOutOfRangeException();
                 }
 
-                // check if out side bounds of map or we have hit our own tail\other part of snake
+                // Check if out side bounds of map or we have hit our own tail\other part of snake
                 if (point.X >= _display.Length || point.Y >= _display[0].Length || point.X < 0 || point.Y < 0 ||
                     _snake.Skip(1).Contains(point))
                 {
@@ -167,7 +167,7 @@ namespace Commands.TerminalCommands.Games
                 item.Value = SnakeChar;
                 OutPutDisplayItem(item);
                 if (item.Point.X != head.X ||
-                    item.Point.Y != head.Y) // if head is same space tail was we don't want to blank it
+                    item.Point.Y != head.Y) // If head is same space tail was we don't want to blank it
                 {
                     UpdateDisplayElementFromPoint(tail, Empty);
                 }

--- a/Commands/TerminalCommands/Network/CheckDomain.cs
+++ b/Commands/TerminalCommands/Network/CheckDomain.cs
@@ -7,7 +7,7 @@ namespace Commands.TerminalCommands.Network
     public class CheckDomain : ITerminalCommand
     {
         /*
-         Check  if an IP dor domain is down.
+         Check if an IP dor domain is down.
          */
         public string Name => "icheck";
 
@@ -25,7 +25,7 @@ namespace Commands.TerminalCommands.Network
             }
             catch
             {
-                FileSystem.ErrorWriteLine("You must specify a domain or an IP address to check . Ex.: icheck google.com");
+                FileSystem.ErrorWriteLine("You must specify a domain or an IP address to check. Eg.: icheck google.com");
             }
         }
     }

--- a/Commands/TerminalCommands/Network/EmailClient.cs
+++ b/Commands/TerminalCommands/Network/EmailClient.cs
@@ -19,27 +19,27 @@ namespace Commands.TerminalCommands.Network
             Console.WriteLine("**********Email Sender Client**************");
             Console.WriteLine("*******************************************");
             Console.WriteLine(" ");
-            //difine the email parameters
-            Console.WriteLine("** Enter your eMail address **");
+            // Define the email parameters.
+            Console.WriteLine("** Enter your eMail Address **");
             s_mailFrom = Console.ReadLine();
             Console.WriteLine("** Enter your eMail Name (default blank) **");
             if (String.IsNullOrWhiteSpace(s_mailName = Console.ReadLine()))
             {
                 s_mailName = "";
             }
-            Console.WriteLine("** Enter your eMail password **");
+            Console.WriteLine("** Enter your eMail Password **");
             s_mailPass = PasswordValidator.ConvertSecureStringToString(PasswordValidator.GetHiddenConsoleInput());
             Console.WriteLine();
-            Console.WriteLine("** Enter destination eMail address **");
+            Console.WriteLine("** Enter destination eMail Address **");
             s_mailTo = Console.ReadLine();
-            Console.WriteLine("** Enter eMail title **");
+            Console.WriteLine("** Enter eMail Title **");
             s_mailTitle = Console.ReadLine();
-            Console.WriteLine("** Enter eMail body content **");
+            Console.WriteLine("** Enter eMail Body Content **");
             s_mailBody = Console.ReadLine();
             //-----------------------------------
 
 
-            //sending the mail
+            // Sending the mail.
             try
             {
                 eMailS.MailSend(s_mailFrom, s_mailName, s_mailPass, s_mailTo, s_mailTitle, s_mailBody);

--- a/Commands/TerminalCommands/Network/ExternalIp.cs
+++ b/Commands/TerminalCommands/Network/ExternalIp.cs
@@ -8,7 +8,7 @@ namespace Commands.TerminalCommands.Network
     public class ExternalIp : ITerminalCommand
     {
         /*
-         * Display machine external IP.
+         * Display machine's external IP.
          */
         public string Name => "extip";
 
@@ -22,7 +22,7 @@ namespace Commands.TerminalCommands.Network
                              .Matches(externalIP)[0].ToString();
                 Console.WriteLine("Your external IP address is: " + externalIP);
             }
-            catch { FileSystem.ErrorWriteLine("Canno't verify external IP. Check your internet connection!"); }
+            catch { FileSystem.ErrorWriteLine("Cannot verify external IP address. Check your internet connection!"); }
         }
     }
 }

--- a/Commands/TerminalCommands/Network/InternetSpeed.cs
+++ b/Commands/TerminalCommands/Network/InternetSpeed.cs
@@ -15,21 +15,21 @@ namespace Commands.TerminalCommands.Network
             Console.WriteLine("*******************************************");
             Console.WriteLine(" ");
 
-            if (Core.NetWork.IntertCheck()) //check internet connection
+            if (Core.NetWork.IntertCheck()) // Check internet connection.
             {
-                // Create Object Of WebClient
+                // Create Object Of WebClient.
                 WebClient wc = new WebClient();
 
-                //DateTime Variable To Store Download Start Time.
+                // Download Start Time.
                 DateTime dt1 = DateTime.Now;
 
-                //Number Of Bytes Downloaded Are Stored In ‘data’
+                // Number Of Bytes Downloaded.
                 byte[] data = wc.DownloadData("http://www.google.com");
 
-                //DateTime Variable To Store Download End Time.
+                // Download End Time.
                 DateTime dt2 = DateTime.Now;
 
-                //To Calculate Speed in Kb Divide Value Of data by 1024 And Then by End Time Subtract Start Time To Know Download Per Second.
+                // Calculate Speed in Kb Divide Value Of data by 1024 And Then by End Time Subtract Start Time To Know Download Per Second.
                 Console.WriteLine(Math.Round((data.Length / 1024) / (dt2 - dt1).TotalSeconds, 2) + " Kb/s with Google");
             }
             else

--- a/Commands/TerminalCommands/Network/Ping.cs
+++ b/Commands/TerminalCommands/Network/Ping.cs
@@ -16,7 +16,7 @@ Example 1: ping google.com  (for normal ping with 4 replies)
 Example 2: ping google.com -t 10  (for 10 replies)
 Example 3: ping google.com -t  (infinite replies)
 
-Ping with -t can be canceled with CTRL+X key combination.    
+Ping with -t can be canceled with CTRL+X key combination.
 ";
 
         public void Execute(string args)

--- a/Commands/TerminalCommands/Network/PortScanner.cs
+++ b/Commands/TerminalCommands/Network/PortScanner.cs
@@ -12,15 +12,15 @@ namespace Commands.TerminalCommands.Network
         private static bool s_pingCheck= false;
         private static string s_helpMessage = @"Usage of cport command:
 
-    Example 1: cport IPAddress/HostName -p 80   (checks if port 80 is open)
-    Example 2: cport IPAddress/HostName -p 1-200   (checks if any port is open from 1 to 200)
-    Example 3: cport stimeout 100   (Set check port time out in milliseconds. Default value is 500.)
+    Example 1: cport IPAddress/HostName -p 80   (Checks if port 80 is open)
+    Example 2: cport IPAddress/HostName -p 1-200   (Checks if any port from 1 to 200 is open)
+    Example 3: cport stimeout 100   (Sets check port time out in milliseconds. Default value is 500)
     Example 4: cport rtimeout   (Reads the current time out value)
          
-    cport check command can be used with --noping parameter for disable ping check on hostname/ip.
-    Example: cport IPAddress/HostName -p 80 --noping    
+    cport check command can be used with --noping parameter to disable ping check on hostname/ip.
+    Example: cport IPAddress/HostName -p 80 --noping
 
-    Port range scan can be canceled with CTRL+X key combination.    
+    Port range scan can be canceled with CTRL+X key combination.
 ";
 
         public void Execute(string args)

--- a/Commands/TerminalCommands/Network/WGet.cs
+++ b/Commands/TerminalCommands/Network/WGet.cs
@@ -25,13 +25,13 @@ namespace Commands.TerminalCommands.Network
         private static MatchCollection s_match2;
         private static MatchCollection s_match;
         private static AutoResetEvent s_resetEvent = new AutoResetEvent(false);
-        private static string s_helpMessage = @"Usage: wget <url> . Or with paramters:
+        private static string s_helpMessage = @"Usage: wget <url> . Or with parameters:
 
    -h : Display this message.
    -o : Save to a specific directory.
         Example: wget <url> -o <directory_path>
 
-    WGet command can be used with --noping parameter for disable ping check on hostname/ip.
+    WGet command can be used with --noping parameter to disable ping check on hostname/ip.
         Example: wget <url> -o <directory_path> --noping
 ";
         public void Execute(string arg)
@@ -128,7 +128,7 @@ namespace Commands.TerminalCommands.Network
             s_stopWatch.Stop();
             s_timeSpan = s_stopWatch.Elapsed;
             Console.WriteLine("Downloaded in " + dlocation + @"\" + fileUrl);
-            Console.WriteLine($"Elapsed download time: {s_timeSpan.Seconds} seconds ");
+            Console.WriteLine($"Elapsed download time: {s_timeSpan.Seconds} seconds");
             s_resetEvent.Set();
         }
 
@@ -143,7 +143,7 @@ namespace Commands.TerminalCommands.Network
 
             if (!FileSystem.CheckPermission(s_urlFirst, true, CheckType.Directory))
             {
-                FileSystem.ErrorWriteLine($"Access denied to direcotry: {s_urlFirst}");
+                FileSystem.ErrorWriteLine($"Access denied to directory: {s_urlFirst}");
                 return;
             }
 
@@ -159,7 +159,7 @@ namespace Commands.TerminalCommands.Network
             s_stopWatch.Stop();
             s_timeSpan = s_stopWatch.Elapsed;
             Console.WriteLine("Downloaded in " + s_urlFirst + @"\" + fileUrl2);
-            Console.WriteLine($"Elapsed download time: {s_timeSpan.Seconds} seconds ");
+            Console.WriteLine($"Elapsed download time: {s_timeSpan.Seconds} seconds");
             s_resetEvent.Set();
         }
     }

--- a/Commands/TerminalCommands/PasswordManager/PManager.cs
+++ b/Commands/TerminalCommands/PasswordManager/PManager.cs
@@ -8,7 +8,8 @@ using PasswordValidator = Core.Encryption.PasswordValidator;
 
 namespace Commands.TerminalCommands.PasswordManager
 {
-    /*Simple password manager to store localy sensitive authentification data from a specific application.
+    /*
+      Simple password manager to locally store sensitive authentification data from a specific application.
       Using Rijndael AES-256bit encryption for data and Argon2 for master password hash.
      */
     public class PManager : ITerminalCommand
@@ -16,10 +17,10 @@ namespace Commands.TerminalCommands.PasswordManager
         public string Name => "pwm";
         private static int s_tries = 0;
         private static JavaScriptSerializer s_serializer;
-        private static string s_helpMessage = @"A simple password manager to store locally the authentication data encrypted for a application using Rijndael AES-256 and Argon2 for password hash.
+        private static string s_helpMessage = @"A simple password manager to locally store the authentification data encrypted for an application using Rijndael AES-256 and Argon2 for password hash.
 Usage of Password Manager commands:
-  -h       : Display this message.
-  -createv : Create a new vault.
+  -h       : Displays this message.
+  -createv : Creates a new vault.
   -delv    : Deletes an existing vault.
   -listv   : Displays the current vaults.
   -addapp  : Adds a new application to vault.
@@ -74,7 +75,7 @@ Usage of Password Manager commands:
             s_tries++;
             if (s_tries >= 3)
             {
-                FileSystem.ColorConsoleTextLine(ConsoleColor.Red, "You have exceeded the number of tries!");
+                FileSystem.ColorConsoleTextLine(ConsoleColor.Red, "You have exceeded the maximum number of tries!");
                 s_tries = 0;
                 return true;
             }
@@ -103,7 +104,7 @@ Usage of Password Manager commands:
                 }
                 else if (string.Join("\n", vaultFiles).Contains($"{vaultName}.x"))
                 {
-                    FileSystem.ColorConsoleTextLine(ConsoleColor.Yellow, $"Vault {vaultName} already exist!");
+                    FileSystem.ColorConsoleTextLine(ConsoleColor.Yellow, $"Vault {vaultName} already exists!");
                 }
                 else
                 {
@@ -243,7 +244,7 @@ Usage of Password Manager commands:
         }
 
         /// <summary>
-        /// Add new application to a current vault.
+        /// Add new application to the current vault.
         /// </summary>
         private static void AddPasswords()
         {
@@ -614,7 +615,7 @@ Usage of Password Manager commands:
         /// <summary>
         /// Color a word from a string.
         /// </summary>
-        /// <param name="beforeText">Text to be added befor word.</param>
+        /// <param name="beforeText">Text to be added before word.</param>
         /// <param name="word">Word to be colored.</param>
         /// <param name="afterText">Text after the colored word.</param>
         /// <param name="color">Console color for the metioned word.</param>

--- a/Commands/TerminalCommands/Roslyn/AddonManagement.cs
+++ b/Commands/TerminalCommands/Roslyn/AddonManagement.cs
@@ -27,7 +27,7 @@ namespace Commands.TerminalCommands.Roslyn
         private string _addonDir = string.Empty;
         private string _helpMessage = @"
  Usage: ! <command_name>
- Can be used with the follwing parameters:
+ Can be used with the following parameters:
 
    -h     :  Displays help message.
    -p     :  Uses command with parameters.
@@ -37,7 +37,7 @@ namespace Commands.TerminalCommands.Roslyn
                 Example: ! -add <file_name_with_code> -c <command_name>|<command_description>
    -del   :  Deletes an Add-on.
                 Example: ! -del <command_name>
-   -list  :  Display the list of the saved add-ons with description.
+   -list  :  Displays the list of the saved add-ons with description.
 ";
 
 
@@ -86,7 +86,7 @@ namespace Commands.TerminalCommands.Roslyn
         {
             string fileName;
             string description;
-            string outList = "List of Add-ons commands:\n\n";
+            string outList = "List of Add-on commands:\n\n";
             if (!Directory.Exists(addonDir))
             {
                 FileSystem.ErrorWriteLine($"Directory {addonDir} does not exist!");
@@ -165,7 +165,7 @@ namespace Commands.TerminalCommands.Roslyn
                     string fileContent = $"//D:{description}" + Environment.NewLine;
                     fileContent += stringReader.ReadToEnd();
                     File.WriteAllText(addonDir + $"\\{command}.x", fileContent);
-                    Console.WriteLine($"Add '{command}' added!");
+                    Console.WriteLine($"Add-on '{command}' added!");
                 }
             }
             catch (Exception e)
@@ -180,7 +180,7 @@ namespace Commands.TerminalCommands.Roslyn
                 ParseCode(addonDir, command);
                 if (_commandCheck)
                 {
-                    Console.WriteLine($"The following add-on does not exist: {command}");
+                    Console.WriteLine($"The following Add-on does not exist: {command}");
                     _commandCheck = false;
                     return;
                 }

--- a/Commands/TerminalCommands/Roslyn/Compiler.cs
+++ b/Commands/TerminalCommands/Roslyn/Compiler.cs
@@ -13,7 +13,7 @@ namespace Commands.TerminalCommands.Roslyn
     public class Compiler : ITerminalCommand
     {
         /*
-         Compiles C# in memory usint Roslyn 
+         Compiles C# in memory using Roslyn 
          */
         public string Name => "ccs";
         private string _codeToRun;
@@ -25,7 +25,7 @@ namespace Commands.TerminalCommands.Roslyn
             string param = string.Empty;
             if (args.Length == 3)
             {
-                FileSystem.ErrorWriteLine($"You must provide an C# file for complile.");
+                FileSystem.ErrorWriteLine($"You must provide a C# file for compilation.");
                 return;
             }
 

--- a/Commands/TerminalCommands/UI/UIManagement.cs
+++ b/Commands/TerminalCommands/UI/UIManagement.cs
@@ -10,12 +10,12 @@ namespace Commands.TerminalCommands.UI
         private string _regUI;
         List<string> _colors = new List<string>() { "darkred", "darkgreen", "darkyellow", "darkmagenta", "darkcyan", "darkgray", "darkblue", "red", "green", "yellow", "white", "magenta", "cyan", "gray", "blue" };
         List<string> _indicators = new List<string>() { ">", "->", "=>", "$", ">>" };
-        private string _helpMessage = @"Usage of  UI PS1(Prompt string 1) command:
- ::Predifined Colors: darkred, darkgreen, darkyellow, darkmagenta, darkcyan, darkgray, darkblue,
-                      red, green, yellow, white, magenta, cyan, gray, blue 
- ::Predifined indicators: > , ->, =>, $, >>
+        private string _helpMessage = @"Usage of UI PS1 (Prompt string 1) command:
+ ::Predefined Colors: darkred, darkgreen, darkyellow, darkmagenta, darkcyan, darkgray, darkblue,
+                      red, green, yellow, white, magenta, cyan, gray, blue
+ ::Predefined Indicators: >, ->, =>, $, >>
 
- -h : Displys this help message.
+ -h : Displays this help message.
  -u : Enables or disables current user@machine information with a predefined color from list:
        Example1: ui -u -c <color> :e  -- enables information with a predefined color from list.
        Example2: ui -u -c <color> :d  -- disables information (need to specify color anyway).
@@ -71,7 +71,7 @@ namespace Commands.TerminalCommands.UI
                 return;
             }
 
-            // Display help message
+            // Display help message.
             if (arg == $"{Name} -h")
             {
                 Console.WriteLine(_helpMessage);


### PR DESCRIPTION
Note:
- Changes are scoped to the `Commands` project
- Some changes are subjective (wording)
- Some potential grammar mistakes were left in

I'm not sure what the prefered formatting is, as there are multiple conventions used. For example comments can be:
```cs
//all lowercase without space at the beginning
```
```cs
// First letter is uppercase, no dot
```
```cs
// First letter is uppercase and there is a dot at the end.
```

Another common offender is strings concatenation vs. interpolation.