### PR TITLE
Simplify file system

### DIFF
--- a/Commands/TerminalCommands/ConsoleSystem/ListDirectories.cs
+++ b/Commands/TerminalCommands/ConsoleSystem/ListDirectories.cs
@@ -456,7 +456,7 @@ Commands can be canceled with CTRL+X key combination.
             if (displaySizes)
             {
                 string currentDirectorySize =
-                    FileSystem.GetDirSize(new DirectoryInfo(s_currentDirectory));
+                    FileSystem.GetDirectorySizeString(new DirectoryInfo(s_currentDirectory));
 
                 Console.WriteLine("---------------------------------------------\n");
                 Console.WriteLine($"Current directory size: {currentDirectorySize}\n");
@@ -499,7 +499,7 @@ Commands can be canceled with CTRL+X key combination.
                             else
                             {
                                 if (creationTime)
-                                    FileSystem.ColorConsoleTextLine(ConsoleColor.DarkCyan, FileSystem.GetCreationDateDirInfo(directoryInfo));
+                                    FileSystem.ColorConsoleTextLine(ConsoleColor.DarkCyan, FileSystem.GetCreationDateString(directoryInfo));
                                 else
                                     FileSystem.ColorConsoleTextLine(ConsoleColor.DarkCyan, directoryInfo.Name);
                             }
@@ -523,7 +523,7 @@ Commands can be canceled with CTRL+X key combination.
                         return;
                     if (displaySizes)
                     {
-                        if (!GlobalVariables.excludeFiles.Contains(file.Name) && FileSystem.CheckPermission(file.FullName, false, FileSystem.CheckType.File))
+                        if (!GlobalVariables.excludeFiles.Contains(file.Name) && FileSystem.HasFilePermissions(file.FullName, false))
                         {
                             string formattedText = GetFormattedFileInfoText(file, displaySizes);
                             if (saveToFile)
@@ -533,7 +533,7 @@ Commands can be canceled with CTRL+X key combination.
                             else
                             {
                                 if (creationTime)
-                                    Console.WriteLine(FileSystem.GetCreationDateFileInfo(file));
+                                    Console.WriteLine(FileSystem.GetCreationDateString(file));
                                 else
                                     DisplayFileInfoText(formattedText, highlightSearchText);
                             }
@@ -551,7 +551,7 @@ Commands can be canceled with CTRL+X key combination.
                             else
                             {
                                 if (creationTime)
-                                    Console.WriteLine(FileSystem.GetCreationDateFileInfo(file));
+                                    Console.WriteLine(FileSystem.GetCreationDateString(file));
                                 else
                                     DisplayFileInfoText(formattedText, highlightSearchText);
                             }
@@ -571,7 +571,7 @@ Commands can be canceled with CTRL+X key combination.
         private static string GetFormattedFileInfoText(FileInfo fileInfo, bool displaySizes)
         {
             return displaySizes
-                ? fileInfo.Name.PadRight(50, ' ') + $"Size:  {FileSystem.GetFileSize(fileInfo.DirectoryName + "\\" + fileInfo.Name, false)}"
+                ? fileInfo.Name.PadRight(50, ' ') + $"Size:  {FileSystem.GetFileSizeString(fileInfo.DirectoryName + "\\" + fileInfo.Name)}"
                 : fileInfo.Name;
         }
 

--- a/Commands/TerminalCommands/ConsoleSystem/PCInfo.cs
+++ b/Commands/TerminalCommands/ConsoleSystem/PCInfo.cs
@@ -135,8 +135,8 @@ namespace Commands.TerminalCommands.ConsoleSystem
         {
             var ram = new Microsoft.VisualBasic.Devices.ComputerInfo();
             FileSystem.ColorConsoleText(ConsoleColor.Green, "RAM");
-            string ramAvailable = FileSystem.GetSize(ram.AvailablePhysicalMemory.ToString(), false);
-            string ramTotal = FileSystem.GetSize(ram.TotalPhysicalMemory.ToString(), false);
+            string ramAvailable = FileSystem.GetFileSizeString((double)ram.AvailablePhysicalMemory);
+            string ramTotal = FileSystem.GetFileSizeString((double)ram.TotalPhysicalMemory);
             Console.WriteLine($": { ramAvailable} Available / {ramTotal} Total");
         }
 

--- a/Commands/TerminalCommands/DirFiles/FCopy.cs
+++ b/Commands/TerminalCommands/DirFiles/FCopy.cs
@@ -118,8 +118,8 @@ namespace Commands.TerminalCommands.DirFiles
                                         {
                                             var hash = crc32.ComputeHash(stream);
                                             crcSource = BitConverter.ToString(hash).Replace("-", "").ToLowerInvariant();
-                                            Console.WriteLine("Source File: " + Source + " | CRC: " + crcSource + " | Size: " + FileSystem.GetFileSize(Source, false));
-                                            sizeSourceFiles += Double.Parse(FileSystem.GetFileSize(Source, true));
+                                            Console.WriteLine("Source File: " + Source + " | CRC: " + crcSource + " | Size: " + FileSystem.GetFileSizeString(Source));
+                                            sizeSourceFiles += FileSystem.GetFileSize(Source);
                                         }
                                     }
                                     else
@@ -213,8 +213,8 @@ namespace Commands.TerminalCommands.DirFiles
                                     {
                                         var hash = crc32.ComputeHash(stream);
                                         crcDestination = BitConverter.ToString(hash).Replace("-", "").ToLowerInvariant();
-                                        Console.WriteLine("Destination File: " + Destination + " | CRC: " + crcDestination + " | Size: " + FileSystem.GetFileSize(Destination, false));
-                                        sizeDestinationFiles += Double.Parse(FileSystem.GetFileSize(Destination, true));
+                                        Console.WriteLine("Destination File: " + Destination + " | CRC: " + crcDestination + " | Size: " + FileSystem.GetFileSizeString(Destination));
+                                        sizeDestinationFiles += FileSystem.GetFileSize(Destination);
                                     }
                                 }
                                 //--------------------------------
@@ -276,8 +276,8 @@ namespace Commands.TerminalCommands.DirFiles
                                         {
                                             var hash = crc32.ComputeHash(stream);
                                             crcSource = BitConverter.ToString(hash).Replace("-", "").ToLowerInvariant();
-                                            Console.WriteLine("Source File: " + Source + " | CRC: " + crcSource + " | Size: " + FileSystem.GetFileSize(Source, false));
-                                            sizeSourceFiles += Double.Parse(FileSystem.GetFileSize(Source, true));
+                                            Console.WriteLine("Source File: " + Source + " | CRC: " + crcSource + " | Size: " + FileSystem.GetFileSizeString(Source));
+                                            sizeSourceFiles += FileSystem.GetFileSize(Source);
                                         }
                                     }
                                     else
@@ -374,8 +374,8 @@ namespace Commands.TerminalCommands.DirFiles
                                     {
                                         var hash = crc32.ComputeHash(stream);
                                         crcDestination = BitConverter.ToString(hash).Replace("-", "").ToLowerInvariant();
-                                        Console.WriteLine("Destination File: " + Destination + " | CRC: " + crcDestination + " | Size: " + FileSystem.GetFileSize(Destination, false));
-                                        sizeDestinationFiles += Double.Parse(FileSystem.GetFileSize(Destination, true));
+                                        Console.WriteLine("Destination File: " + Destination + " | CRC: " + crcDestination + " | Size: " + FileSystem.GetFileSizeString(Destination));
+                                        sizeDestinationFiles += FileSystem.GetFileSize(Destination);
                                     }
                                 }
                                 //--------------------------------
@@ -409,8 +409,8 @@ namespace Commands.TerminalCommands.DirFiles
                             {
                                 var hash = crc32.ComputeHash(stream);
                                 crcSource = BitConverter.ToString(hash).Replace("-", "").ToLowerInvariant();
-                                Console.WriteLine("Source File: " + Source + " | CRC: " + crcSource + " | Size: " + FileSystem.GetFileSize(Source, false));
-                                sizeSourceFiles += Double.Parse(FileSystem.GetFileSize(Source, true));
+                                Console.WriteLine("Source File: " + Source + " | CRC: " + crcSource + " | Size: " + FileSystem.GetFileSizeString(Source));
+                                sizeSourceFiles += FileSystem.GetFileSize(Source);
                             }
                         }
                         else
@@ -450,7 +450,7 @@ namespace Commands.TerminalCommands.DirFiles
                         {
                             var hash = crc32.ComputeHash(stream);
                             crcDestination = BitConverter.ToString(hash).Replace("-", "").ToLowerInvariant();
-                            Console.WriteLine("Destination File: " + Destination + " | CRC: " + crcDestination + " | Size: " + FileSystem.GetFileSize(Destination, false));
+                            Console.WriteLine("Destination File: " + Destination + " | CRC: " + crcDestination + " | Size: " + FileSystem.GetFileSizeString(Destination));
                         }
                     }
 

--- a/Commands/TerminalCommands/DirFiles/FMove.cs
+++ b/Commands/TerminalCommands/DirFiles/FMove.cs
@@ -121,8 +121,8 @@ namespace Commands.TerminalCommands.DirFiles
                                         {
                                             var hash = crc32.ComputeHash(stream);
                                             crcSource = BitConverter.ToString(hash).Replace("-", "").ToLowerInvariant();
-                                            Console.WriteLine("Source File: " + Source + " | CRC: " + crcSource + " | Size: " + FileSystem.GetFileSize(Source, false));
-                                            sizeSourceFiles += Double.Parse(FileSystem.GetFileSize(Source, true));
+                                            Console.WriteLine("Source File: " + Source + " | CRC: " + crcSource + " | Size: " + FileSystem.GetFileSizeString(Source));
+                                            sizeSourceFiles += FileSystem.GetFileSize(Source);
                                         }
                                     }
                                     else
@@ -216,8 +216,8 @@ namespace Commands.TerminalCommands.DirFiles
                                     {
                                         var hash = crc32.ComputeHash(stream);
                                         crcDestination = BitConverter.ToString(hash).Replace("-", "").ToLowerInvariant();
-                                        Console.WriteLine("Destination File: " + Destination + " | CRC: " + crcDestination + " | Size: " + FileSystem.GetFileSize(Destination, false));
-                                        sizeDestinationFiles += Double.Parse(FileSystem.GetFileSize(Destination, true));
+                                        Console.WriteLine("Destination File: " + Destination + " | CRC: " + crcDestination + " | Size: " + FileSystem.GetFileSizeString(Destination));
+                                        sizeDestinationFiles += FileSystem.GetFileSize(Destination);
                                     }
                                 }
                                 //--------------------------------
@@ -279,8 +279,8 @@ namespace Commands.TerminalCommands.DirFiles
                                         {
                                             var hash = crc32.ComputeHash(stream);
                                             crcSource = BitConverter.ToString(hash).Replace("-", "").ToLowerInvariant();
-                                            Console.WriteLine("Source File: " + Source + " | CRC: " + crcSource + " | Size: " + FileSystem.GetFileSize(Source, false));
-                                            sizeSourceFiles += Double.Parse(FileSystem.GetFileSize(Source, true));
+                                            Console.WriteLine("Source File: " + Source + " | CRC: " + crcSource + " | Size: " + FileSystem.GetFileSizeString(Source));
+                                            sizeSourceFiles += FileSystem.GetFileSize(Source);
                                         }
                                     }
                                     else
@@ -377,8 +377,8 @@ namespace Commands.TerminalCommands.DirFiles
                                     {
                                         var hash = crc32.ComputeHash(stream);
                                         crcDestination = BitConverter.ToString(hash).Replace("-", "").ToLowerInvariant();
-                                        Console.WriteLine("Destination File: " + Destination + " | CRC: " + crcDestination + " | Size: " + FileSystem.GetFileSize(Destination, false));
-                                        sizeDestinationFiles += Double.Parse(FileSystem.GetFileSize(Destination, true));
+                                        Console.WriteLine("Destination File: " + Destination + " | CRC: " + crcDestination + " | Size: " + FileSystem.GetFileSizeString(Destination));
+                                        sizeDestinationFiles += FileSystem.GetFileSize(Destination);
                                     }
                                 }
                                 //--------------------------------
@@ -414,8 +414,8 @@ namespace Commands.TerminalCommands.DirFiles
                             {
                                 var hash = crc32.ComputeHash(stream);
                                 crcSource = BitConverter.ToString(hash).Replace("-", "").ToLowerInvariant();
-                                Console.WriteLine("Source File: " + Source + " | CRC: " + crcSource + " | Size: " + FileSystem.GetFileSize(Source, false));
-                                sizeSourceFiles += Double.Parse(FileSystem.GetFileSize(Source, true));
+                                Console.WriteLine("Source File: " + Source + " | CRC: " + crcSource + " | Size: " + FileSystem.GetFileSizeString(Source));
+                                sizeSourceFiles += FileSystem.GetFileSize(Source);
                             }
                         }
                         else
@@ -455,8 +455,8 @@ namespace Commands.TerminalCommands.DirFiles
                         {
                             var hash = crc32.ComputeHash(stream);
                             crcDestination = BitConverter.ToString(hash).Replace("-", "").ToLowerInvariant();
-                            Console.WriteLine("Destination File: " + Destination + " | CRC: " + crcDestination + " | Size: " + FileSystem.GetFileSize(Destination, false));
-                            sizeDestinationFiles += Double.Parse(FileSystem.GetFileSize(Destination, true));
+                            Console.WriteLine("Destination File: " + Destination + " | CRC: " + crcDestination + " | Size: " + FileSystem.GetFileSizeString(Destination));
+                            sizeDestinationFiles += FileSystem.GetFileSize(Destination);
                         }
                     }
 

--- a/Commands/TerminalCommands/DirFiles/Locate.cs
+++ b/Commands/TerminalCommands/DirFiles/Locate.cs
@@ -88,7 +88,7 @@ Command can be canceled with CTRL+X key combination.
                 foreach (var file in filesList)
                 {
                     FileInfo fileInfo = new FileInfo(file);
-                    if (fileInfo.Name.ToLower().Contains(fileName.ToLower()) && FileSystem.CheckPermission(fileInfo.FullName, false, FileSystem.CheckType.Directory))
+                    if (fileInfo.Name.ToLower().Contains(fileName.ToLower()) && FileSystem.HasFilePermissions(fileInfo.FullName, false))
                     {
                         if (saveToFile)
                         {
@@ -104,7 +104,7 @@ Command can be canceled with CTRL+X key combination.
                 foreach (var dir in dirsList)
                 {
                     DirectoryInfo directoryInfo = new DirectoryInfo(dir);
-                    if (directoryInfo.Name.ToLower().Contains(fileName.ToLower()) && FileSystem.CheckPermission(directoryInfo.FullName, false, FileSystem.CheckType.Directory))
+                    if (directoryInfo.Name.ToLower().Contains(fileName.ToLower()) && FileSystem.HasFilePermissions(directoryInfo.FullName, false))
                     {
                         if (saveToFile)
                         {

--- a/Commands/TerminalCommands/DirFiles/StringView.cs
+++ b/Commands/TerminalCommands/DirFiles/StringView.cs
@@ -111,12 +111,11 @@ Commands can be canceled with CTRL+X key combination.
                         break;
                     case "-n":
                         string lineCounter = arg.Split(' ')[1];
-                        if (!FileSystem.IsNumberAllowed(lineCounter))
+                        if (!int.TryParse(lineCounter, out int lines))
                         {
                             FileSystem.ErrorWriteLine("Invalid parameter. You need to provide how many lines you want to display!");
                             return;
                         }
-                        int lines = Int32.Parse(lineCounter);
                         string filePath = FileSystem.SanitizePath(arg.SplitByText(lineCounter + " ", 1), s_currentDirectory);
                         GlobalVariables.eventKeyFlagX = true;
                         Core.Commands.CatCommand.OuputFirtsLines(filePath, lines);

--- a/Commands/TerminalCommands/Network/PortScanner.cs
+++ b/Commands/TerminalCommands/Network/PortScanner.cs
@@ -29,9 +29,7 @@ namespace Commands.TerminalCommands.Network
             {
                 GlobalVariables.eventCancelKey = false;
                 string cTimeOut = RegistryManagement.regKey_Read(GlobalVariables.regKeyName, GlobalVariables.regCportTimeOut);
-                if (FileSystem.IsNumberAllowed(cTimeOut) && !string.IsNullOrEmpty(cTimeOut))
-                    s_timeOut = Int32.Parse(cTimeOut);
-                else
+                if (!int.TryParse(cTimeOut, out s_timeOut))
                 {
                     s_timeOut = 500;
                     RegistryManagement.regKey_WriteSubkey(GlobalVariables.regKeyName, GlobalVariables.regCportTimeOut, "500");

--- a/Commands/TerminalCommands/Network/WGet.cs
+++ b/Commands/TerminalCommands/Network/WGet.cs
@@ -6,7 +6,6 @@ using System.IO;
 using System.Net;
 using System.Text.RegularExpressions;
 using System.Threading;
-using CheckType = Core.FileSystem.CheckType;
 using System.Net.Http;
 using System.Threading.Tasks;
 
@@ -150,7 +149,7 @@ namespace Commands.TerminalCommands.Network
                 return;
             }
 
-            if (!FileSystem.CheckPermission(s_urlFirst, true, CheckType.Directory))
+            if (!FileSystem.HasFilePermissions(s_urlFirst, true))
             {
                 FileSystem.ErrorWriteLine($"Access denied to directory: {s_urlFirst}");
                 return;

--- a/Core/Commands/CatCommand.cs
+++ b/Core/Commands/CatCommand.cs
@@ -300,13 +300,11 @@ namespace Core.Commands
             {
                 string firstLine = range.Split('-')[0];
                 string secondLine = range.Split('-')[1];
-                if (!FileSystem.IsNumberAllowed(firstLine) && !FileSystem.IsNumberAllowed(secondLine))
+                if (!int.TryParse(firstLine, out int first) || !int.TryParse(secondLine, out int second))
                 {
                     FileSystem.ErrorWriteLine("Parameter invalid: You need to provide the range of lines for data display! Example: 10-20");
                     return;
                 }
-                int first = Int32.Parse(firstLine);
-                int second = Int32.Parse(secondLine);
 
                 using (var streamReader = new StreamReader(fileName))
                 {


### PR DESCRIPTION
- Split `string GetFileSize(string, bool)` into `double GetFileSize(string)` and `string GetFileSizeString(string)`
- Add `GetFileSizeString(double)`, that the other `GetXSize` methods depend on
- Rename `GetDirSize` to `GetDirectorySizeString`
- Rename `DirectorySize` to `GetDirectorySize`
- Rename `CheckPermission` to `HasFilePermissions`
- Checking for permissions no longer requires specification of: file x directory
- `ErrorWriteLine` writes to `stderr` instead of `stdout`
- Remove `IsNumberAllowed` in favor of `int.TryParse`
- Unite `GetCreationDateFileInfo` and `GetCreationDateDirInfo` into `GetCreationDateString`
- Improve XML documentation