### PR TITLE
Migrate to System.Text.Json

### DIFF
--- a/Commands/TerminalCommands/PasswordManager/PManager.cs
+++ b/Commands/TerminalCommands/PasswordManager/PManager.cs
@@ -1,9 +1,9 @@
 ﻿using Core;
+using Core.SystemTools;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Web.Script.Serialization;
 using PasswordValidator = Core.Encryption.PasswordValidator;
 
 namespace Commands.TerminalCommands.PasswordManager
@@ -16,7 +16,6 @@ namespace Commands.TerminalCommands.PasswordManager
     {
         public string Name => "pwm";
         private static int s_tries = 0;
-        private static JavaScriptSerializer s_serializer;
         private static string s_helpMessage = @"A simple password manager to locally store the authentification data encrypted for an application using Rijndael AES-256 and Argon2 for password hash.
 Usage of Password Manager commands:
   -h       : Displays this message.
@@ -297,8 +296,7 @@ Usage of Password Manager commands:
                 string line;
                 while ((line = reader.ReadLine()) != null)
                 {
-                    s_serializer = new JavaScriptSerializer();
-                    var outJson = s_serializer.Deserialize<Dictionary<string, string>>(line);
+                    var outJson = JsonManage.Deserialize<Dictionary<string, string>>(line);
                     if (line.Length > 0)
                     {
                         if (outJson["site/application"] == application && outJson["account"] == account)
@@ -319,8 +317,7 @@ Usage of Password Manager commands:
                     { "account", account },
                     { "password", password },
                 };
-            s_serializer = new JavaScriptSerializer();
-            string encryptdata = Core.Encryption.AES.Encrypt(decryptVault + "\n" + s_serializer.Serialize(keyValues), masterPassword);
+            string encryptdata = Core.Encryption.AES.Encrypt(decryptVault + "\n" + JsonManage.Serialize(keyValues), masterPassword);
             if (File.Exists(GlobalVariables.passwordManagerDirectory + $"\\{vault}.x"))
             {
                 File.WriteAllText(GlobalVariables.passwordManagerDirectory + $"\\{vault}.x", encryptdata);
@@ -366,8 +363,7 @@ Usage of Password Manager commands:
                 {
                     if (line.Contains(application) && line.Length > 0)
                     {
-                        s_serializer = new JavaScriptSerializer();
-                        var outJson = s_serializer.Deserialize<Dictionary<string, string>>(line);
+                        var outJson = JsonManage.Deserialize<Dictionary<string, string>>(line);
                         if (outJson["site/application"].Contains(application))
                         {
                             Console.WriteLine("-------------------------");
@@ -475,8 +471,7 @@ Usage of Password Manager commands:
                     if (line.Length > 0)
                     {
                         listApps.Add(line);
-                        s_serializer = new JavaScriptSerializer();
-                        var outJson = s_serializer.Deserialize<Dictionary<string, string>>(line);
+                        var outJson = JsonManage.Deserialize<Dictionary<string, string>>(line);
                         if (outJson["site/application"] == application && outJson["account"] == accountName)
                         {
                             listApps.Remove(line);
@@ -574,10 +569,9 @@ Usage of Password Manager commands:
                 string line;
                 while ((line = reader.ReadLine()) != null)
                 {
-                    s_serializer = new JavaScriptSerializer();
                     if (line.Length > 0)
                     {
-                        var outJson = s_serializer.Deserialize<Dictionary<string, string>>(line);
+                        var outJson = JsonManage.Deserialize<Dictionary<string, string>>(line);
                         if (outJson["site/application"] == application && outJson["account"] == accountName)
                         {
                             var keyValues = new Dictionary<string, object>
@@ -587,7 +581,7 @@ Usage of Password Manager commands:
                                  { "password", password },
                             };
                             accountCheck = true;
-                            listApps.Add(s_serializer.Serialize(keyValues));
+                            listApps.Add(JsonManage.Serialize(keyValues));
                         }
                         else
                         {

--- a/Core/Core.csproj
+++ b/Core/Core.csproj
@@ -14,6 +14,8 @@
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -74,7 +76,13 @@
     <Reference Include="Konscious.Security.Cryptography.Blake2, Version=1.0.9.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Konscious.Security.Cryptography.Blake2.1.0.9\lib\net46\Konscious.Security.Cryptography.Blake2.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.6.0.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
+    </Reference>
     <Reference Include="System.Core" />
     <Reference Include="System.Management" />
     <Reference Include="System.Management.Automation, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -82,9 +90,27 @@
       <HintPath>C:\Windows\assembly\GAC_MSIL\System.Management.Automation\1.0.0.0__31bf3856ad364e35\System.Management.Automation.dll</HintPath>
     </Reference>
     <Reference Include="System.Management.Instrumentation" />
+    <Reference Include="System.Memory, Version=4.0.1.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.4.5.5\lib\net461\System.Memory.dll</HintPath>
+    </Reference>
     <Reference Include="System.Numerics" />
     <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.6.0.0\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Text.Encodings.Web, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Encodings.Web.6.0.0\lib\net461\System.Text.Encodings.Web.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Text.Json, Version=6.0.0.5, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Json.6.0.5\lib\net461\System.Text.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net47\System.ValueTuple.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Windows.Forms" />
@@ -121,7 +147,15 @@
     <Compile Include="SystemTools\UI.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\System.Text.Json.6.0.5\build\System.Text.Json.targets" Condition="Exists('..\packages\System.Text.Json.6.0.5\build\System.Text.Json.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\System.Text.Json.6.0.5\build\System.Text.Json.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\System.Text.Json.6.0.5\build\System.Text.Json.targets'))" />
+  </Target>
 </Project>

--- a/Core/Encryption/AES.cs
+++ b/Core/Encryption/AES.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Security.Cryptography;
 using System.Text;
-using System.Web.Script.Serialization;
+using System.Text.Json;
 
 namespace Core.Encryption
 {
@@ -42,10 +42,9 @@ namespace Core.Encryption
                     { "value", encryptedText },
                     { "mac", mac },
                 };
-                JavaScriptSerializer serializer = new JavaScriptSerializer();
                 Argon2.s_argon2.Reset();
                 Argon2.s_argon2.Dispose();
-                return Convert.ToBase64String(encoding.GetBytes(serializer.Serialize(keyValues)));
+                return Convert.ToBase64String(encoding.GetBytes(JsonSerializer.Serialize(keyValues)));
             }
             catch (Exception e)
             {
@@ -71,8 +70,7 @@ namespace Core.Encryption
                 aes.Key = Argon2.Argon2HashPassword(password);
                 byte[] base64Decoded = Convert.FromBase64String(plainText);
                 string base64DecodedStr = encoding.GetString(base64Decoded);
-                JavaScriptSerializer ser = new JavaScriptSerializer();
-                var payload = ser.Deserialize<Dictionary<string, string>>(base64DecodedStr);
+                var payload = JsonSerializer.Deserialize<Dictionary<string, string>>(base64DecodedStr);
                 aes.IV = Convert.FromBase64String(payload["iv"]);
                 ICryptoTransform AESDecrypt = aes.CreateDecryptor(aes.Key, aes.IV);
                 byte[] buffer = Convert.FromBase64String(payload["value"]);

--- a/Core/SystemTools/JsonManage.cs
+++ b/Core/SystemTools/JsonManage.cs
@@ -2,12 +2,22 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Web.Script.Serialization;
+using System.Text.Json;
 
 namespace Core.SystemTools
 {
     public static class JsonManage
     {
+        public static string Serialize<T>(T value)
+        {
+            return JsonSerializer.Serialize(value);
+        }
+
+        public static T Deserialize<T>(string text)
+        {
+            return JsonSerializer.Deserialize<T>(text);
+        }
+
         /// <summary>
         /// Read data from JSON file.
         /// </summary>
@@ -16,8 +26,7 @@ namespace Core.SystemTools
         /// <returns></returns>
         public static T ReadJsonFromFile<T>(string filePath)
         {
-            JavaScriptSerializer serializer = new JavaScriptSerializer();
-            return serializer.Deserialize<T>(File.ReadAllText(filePath));
+            return JsonSerializer.Deserialize<T>(File.ReadAllText(filePath));
         }
 
         /// <summary>
@@ -27,8 +36,7 @@ namespace Core.SystemTools
         /// <param name="ob"></param>
         public static void CreateJsonFile(string filePath, object ob)
         {
-            JavaScriptSerializer serializer = new JavaScriptSerializer();
-            File.WriteAllText(filePath, serializer.Serialize(ob));
+            File.WriteAllText(filePath, JsonSerializer.Serialize(ob));
         }
 
         /// <summary>

--- a/Core/app.config
+++ b/Core/app.config
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.2" newVersion="4.0.1.2" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/Core/packages.config
+++ b/Core/packages.config
@@ -2,5 +2,13 @@
 <packages>
   <package id="Konscious.Security.Cryptography.Argon2" version="1.2.1" targetFramework="net472" />
   <package id="Konscious.Security.Cryptography.Blake2" version="1.0.9" targetFramework="net472" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="6.0.0" targetFramework="net472" />
+  <package id="System.Buffers" version="4.5.1" targetFramework="net472" />
+  <package id="System.Memory" version="4.5.5" targetFramework="net472" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net472" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net472" />
+  <package id="System.Text.Encodings.Web" version="6.0.0" targetFramework="net472" />
+  <package id="System.Text.Json" version="6.0.5" targetFramework="net472" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net472" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
[Motivation](https://docs.microsoft.com/en-us/dotnet/api/system.web.script.serialization.javascriptserializer?view=netframework-4.8#remarks)
> For .NET Framework 4.7.2 and later versions, the APIs in the [System.Text.Json](https://docs.microsoft.com/en-us/dotnet/api/system.text.json?view=netframework-4.8) namespace should be used for serialization and deserialization. For earlier versions of .NET Framework, use [Newtonsoft.Json](https://www.newtonsoft.com/json).

This PR:
- Adds the System.Text.Json package to `Core`
- Exposes (de)serialization methods in `JsonManage`
- Removes usage of System.Web.Script.Serialization APIs