### PR TITLE
V1.5.7

### DIFF
--- a/Commands/CommandRepository.cs
+++ b/Commands/CommandRepository.cs
@@ -63,7 +63,6 @@ namespace Commands
         {
             if (!File.Exists(aliasJsonFile))
             {
-                FileSystem.ErrorWriteLine("Alias file does not exist!");
                 return string.Empty;
             }
             string command = string.Empty;

--- a/Commands/CommandRepository.cs
+++ b/Commands/CommandRepository.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/Commands/Properties/AssemblyInfo.cs
+++ b/Commands/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.5.0.0")]
-[assembly: AssemblyFileVersion("1.5.0.0")]
+[assembly: AssemblyVersion("1.5.1.0")]
+[assembly: AssemblyFileVersion("1.5.1.0")]

--- a/Commands/TerminalCommands/ConsoleSystem/ListDirectories.cs
+++ b/Commands/TerminalCommands/ConsoleSystem/ListDirectories.cs
@@ -523,7 +523,7 @@ Commands can be canceled with CTRL+X key combination.
                         return;
                     if (displaySizes)
                     {
-                        if (!GlobalVariables.excludeFiles.Contains(file.Name) && FileSystem.CheckPermission(file.FullName, false, FileSystem.CheckType.File))
+                        if (!GlobalVariables.excludeFiles.Contains(file.Name))
                         {
                             string formattedText = GetFormattedFileInfoText(file, displaySizes);
                             if (saveToFile)

--- a/Commands/TerminalCommands/DirFiles/Locate.cs
+++ b/Commands/TerminalCommands/DirFiles/Locate.cs
@@ -88,7 +88,7 @@ Command can be canceled with CTRL+X key combination.
                 foreach (var file in filesList)
                 {
                     FileInfo fileInfo = new FileInfo(file);
-                    if (fileInfo.Name.ToLower().Contains(fileName.ToLower()) && FileSystem.CheckPermission(fileInfo.FullName, false, FileSystem.CheckType.Directory))
+                    if (fileInfo.Name.ToLower().Contains(fileName.ToLower()))
                     {
                         if (saveToFile)
                         {
@@ -104,7 +104,7 @@ Command can be canceled with CTRL+X key combination.
                 foreach (var dir in dirsList)
                 {
                     DirectoryInfo directoryInfo = new DirectoryInfo(dir);
-                    if (directoryInfo.Name.ToLower().Contains(fileName.ToLower()) && FileSystem.CheckPermission(directoryInfo.FullName, false, FileSystem.CheckType.Directory))
+                    if (directoryInfo.Name.ToLower().Contains(fileName.ToLower()))
                     {
                         if (saveToFile)
                         {
@@ -119,7 +119,7 @@ Command can be canceled with CTRL+X key combination.
                         SearchFile(dir, fileName, outputFile, saveToFile);
                 }
             }
-            catch (UnauthorizedAccessException){}
+            catch {}
         }
     }
 }

--- a/Commands/TerminalCommands/Network/WGet.cs
+++ b/Commands/TerminalCommands/Network/WGet.cs
@@ -107,7 +107,8 @@ namespace Commands.TerminalCommands.Network
                 Task.Run(() => DownloadDirectory()).Wait();
                 return;
             }
-            Task.Run(() => DownloadDirectory()).Wait();
+            s_urlFirst = input;
+            Task.Run(() => Download()).Wait();
         }
         //Download file directly in root path
         private static async Task Download()
@@ -125,7 +126,7 @@ namespace Commands.TerminalCommands.Network
             Console.WriteLine($"Downloading {fileUrl} in {dlocation} .......");
             var source = new Uri(s_urlFirst);
             s_stopWatch.Start();
-            var fileName = $"{s_urlFirst}\\{fileUrl}";
+            var fileName = $"{dlocation}\\{fileUrl}";
             using (var s = await s_client.GetStreamAsync(source))
             {
                 using (var fs = new FileStream(fileName, FileMode.Create))
@@ -135,7 +136,7 @@ namespace Commands.TerminalCommands.Network
             }
             s_stopWatch.Stop();
             s_timeSpan = s_stopWatch.Elapsed;
-            Console.WriteLine("Downloaded in " + dlocation + @"\" + fileUrl);
+            Console.WriteLine($"Downloaded in { dlocation}{ fileUrl}");
             Console.WriteLine($"Elapsed download time: {s_timeSpan.Seconds} seconds");
             s_resetEvent.Set();
         }

--- a/Core/FileSystem.cs
+++ b/Core/FileSystem.cs
@@ -97,21 +97,21 @@ namespace Core
         private static double DirectorySize(DirectoryInfo directoryInfo)
         {
             double size = 0;
-
-            FileInfo[] fileInfos = directoryInfo.GetFiles();
-            foreach (var fileInfo in fileInfos)
+            try
             {
-                size += fileInfo.Length;
-            }
+                FileInfo[] fileInfos = directoryInfo.GetFiles();
+                foreach (var fileInfo in fileInfos)
+                {
+                    size += fileInfo.Length;
+                }
 
-            DirectoryInfo[] directoryInfos = directoryInfo.GetDirectories();
-            foreach (var dirInfo in directoryInfos)
-            {
-                if (CheckPermission(dirInfo.FullName, true, CheckType.Directory) == true)
+                DirectoryInfo[] directoryInfos = directoryInfo.GetDirectories();
+                foreach (var dirInfo in directoryInfos)
                 {
                     size += DirectorySize(dirInfo);
                 }
             }
+            catch { }
             return size;
         }
 

--- a/Core/Properties/AssemblyInfo.cs
+++ b/Core/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.4.1.0")]
-[assembly: AssemblyFileVersion("1.4.1.0")]
+[assembly: AssemblyVersion("1.4.2.0")]
+[assembly: AssemblyFileVersion("1.4.2.0")]

--- a/Shell/Properties/AssemblyInfo.cs
+++ b/Shell/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.5.6.0")]
-[assembly: AssemblyFileVersion("1.5.6.0")]
+[assembly: AssemblyVersion("1.5.7.0")]
+[assembly: AssemblyFileVersion("1.5.7.0")]


### PR DESCRIPTION
Fixing ls -s command for display size more accurate and show size on read-only files too.
Fixed locate command to display read-only files.
Fixed wget command to download files in current directory.
Removed display error on alias json files missing on every command typed.