### PR TITLE
1.8.0 hotfixes

### DIFF
--- a/Commands/CommandRepository.cs
+++ b/Commands/CommandRepository.cs
@@ -67,27 +67,23 @@ namespace Commands
                                 if (command.StartsWith('!'))
                                 {
                                     addCommand = command.Substring(1);
-                                    if (!string.IsNullOrEmpty(addCommand))
-                                        GlobalVariables.aliasInParameter.Add($"{addCommand.Trim()}");
+                                    StoreListParameters(addCommand);
                                 }
                                 else if (command.EndsWith('!'))
                                 {
                                     addCommand = command.Substring(0, command.Length - 1);
-                                    if (!string.IsNullOrEmpty(addCommand))
-                                        GlobalVariables.aliasInParameter.Add($"{addCommand.Trim()}");
+                                    StoreListParameters(addCommand);
                                 }
                                 else
                                 {
                                     addCommand = command;
-                                    if (!string.IsNullOrEmpty(addCommand))
-                                        GlobalVariables.aliasInParameter.Add($"{addCommand.Trim()}");
+                                    StoreListParameters(addCommand);
                                 }
                             }
                             else
                             {
                                 addCommand = command;
-                                if (!string.IsNullOrEmpty(addCommand))
-                                    GlobalVariables.aliasInParameter.Add($"{addCommand.Trim()}");
+                                StoreListParameters(addCommand);
                             }
                         }
                     }
@@ -120,6 +116,16 @@ namespace Commands
                 }
             }
             return terminalCommandOut;
+        }
+
+        /// <summary>
+        /// Store command in list.
+        /// </summary>
+        /// <param name="command"></param>
+        private static void StoreListParameters(string command)
+        {
+            if (!string.IsNullOrEmpty(command))
+                GlobalVariables.aliasInParameter.Add($"{command.Trim()}");
         }
 
         /// <summary>

--- a/Commands/CommandRepository.cs
+++ b/Commands/CommandRepository.cs
@@ -57,11 +57,19 @@ namespace Commands
                 GlobalVariables.aliasInParameter.Add(subCommand.Trim());
             else
             {
+                var isWithExclamation = false;
+                // Confirm is without quotes using exclamation mark.
+                if (subCommand.StartsWith("!\""))
+                {
+                    subCommand = subCommand.Replace("!\"", "\"");
+                    isWithExclamation = true;
+                }
+
                 var splitSubcommand = subCommand.Contains('"') ? subCommand.Split('"') : subCommand.Split(' ');
                 foreach (var command in splitSubcommand)
                     if (!command.Contains(commandName) && !string.IsNullOrEmpty(command))
                     {
-                        if (subCommand.Contains('"'))
+                        if (subCommand.StartsWith('"') && !isWithExclamation)
                             GlobalVariables.aliasInParameter.Add($"\"{command.Trim()}\"");
                         else
                             GlobalVariables.aliasInParameter.Add(command.Trim());

--- a/Commands/CommandRepository.cs
+++ b/Commands/CommandRepository.cs
@@ -51,7 +51,14 @@ namespace Commands
 
             // Get the parameter for allias command.
             var subCommand = commandLine.Substring(commandLeng).Trim();
-            if (!string.IsNullOrEmpty(subCommand))
+            if(GlobalVariables.isSingleAlias)
+            {
+                if (subCommand.Contains('"'))
+                    GlobalVariables.aliasInParameter.Add($"\"{subCommand.Trim()}\"");
+                else
+                    GlobalVariables.aliasInParameter.Add(subCommand.Trim());
+               
+            }else  if (!string.IsNullOrEmpty(subCommand))
             {
                 var splitSubcommand = new string[] { };
                 if (subCommand.Contains("!\""))
@@ -145,7 +152,15 @@ namespace Commands
             GlobalVariables.aliasRunFlag = !string.IsNullOrWhiteSpace(command);
 
             var countItems = GlobalVariables.aliasInParameter.Count;
-            if (command.Contains("%"))
+            if (command.Contains("%1") && !command.Contains("%2"))
+            {
+                GlobalVariables.isSingleAlias = true;
+                var concatanate = "";
+                for (int i = 0; i < countItems; i++)
+                    concatanate+=$"{GlobalVariables.aliasInParameter[i]}";
+                command = concatanate.Trim();
+            }
+            else 
                 for (int i = 0; i < countItems; i++)
                     command = command.Replace($"%{i + 1}", GlobalVariables.aliasInParameter[i]);
 

--- a/Commands/CommandRepository.cs
+++ b/Commands/CommandRepository.cs
@@ -51,62 +51,62 @@ namespace Commands
 
             // Get the parameter for allias command.
             var subCommand = commandLine.Substring(commandLeng).Trim();
-            if(GlobalVariables.isSingleAlias)
+            if (GlobalVariables.isSingleAlias)
             {
                 if (subCommand.Contains('"'))
                     GlobalVariables.aliasInParameter.Add($"\"{subCommand.Trim()}\"");
                 else
                     GlobalVariables.aliasInParameter.Add(subCommand.Trim());
-               
-            }else  if (!string.IsNullOrEmpty(subCommand))
+            }
+            else
+            //}else  if (!string.IsNullOrEmpty(subCommand))
+            //{
+            //var splitSubcommand = new string[] { };
+            //if (subCommand.Contains("!\""))
+            //{
+            //    splitSubcommand = subCommand.Split("\"");
+            //    foreach (var command in splitSubcommand)
+            //    {
+            //        if (!command.Contains(commandName) || string.IsNullOrEmpty(command))
+            //        {
+            //            var addCommand = "";
+            //            if (command.Contains('!'))
+            //            {
+            //                if (command.StartsWith('!'))
+            //                {
+            //                    addCommand = command.Substring(1);
+            //                    StoreListParameters(addCommand);
+            //                }
+            //                else if (command.EndsWith('!'))
+            //                {
+            //                    addCommand = command.Substring(0, command.Length - 1);
+            //                    StoreListParameters(addCommand);
+            //                }
+            //                else
+            //                {
+            //                    addCommand = command;
+            //                    StoreListParameters(addCommand);
+            //                }
+            //            }
+            //            else
+            //            {
+            //                addCommand = command;
+            //                StoreListParameters(addCommand);
+            //            }
+            //        }
+            //    }
+            //}
+            //else
             {
-                var splitSubcommand = new string[] { };
-                if (subCommand.Contains("!\""))
-                {
-                    splitSubcommand = subCommand.Split("\"");
-                    foreach (var command in splitSubcommand)
+                var splitSubcommand = subCommand.Contains('"') ? subCommand.Split('"') : subCommand.Split(' ');
+                foreach (var command in splitSubcommand)
+                    if (!command.Contains(commandName) && !string.IsNullOrEmpty(command))
                     {
-                        if (!command.Contains(commandName) || string.IsNullOrEmpty(command))
-                        {
-                            var addCommand = "";
-                            if (command.Contains('!'))
-                            {
-                                if (command.StartsWith('!'))
-                                {
-                                    addCommand = command.Substring(1);
-                                    StoreListParameters(addCommand);
-                                }
-                                else if (command.EndsWith('!'))
-                                {
-                                    addCommand = command.Substring(0, command.Length - 1);
-                                    StoreListParameters(addCommand);
-                                }
-                                else
-                                {
-                                    addCommand = command;
-                                    StoreListParameters(addCommand);
-                                }
-                            }
-                            else
-                            {
-                                addCommand = command;
-                                StoreListParameters(addCommand);
-                            }
-                        }
+                        if (subCommand.Contains('"'))
+                            GlobalVariables.aliasInParameter.Add($"\"{command.Trim()}\"");
+                        else
+                            GlobalVariables.aliasInParameter.Add(command.Trim());
                     }
-                }
-                else
-                {
-                    splitSubcommand = subCommand.Contains('"') ? subCommand.Split('"') : subCommand.Split(' ');
-                    foreach (var command in splitSubcommand)
-                        if (!command.Contains(commandName) && !string.IsNullOrEmpty(command))
-                        {
-                            if (subCommand.Contains('"'))
-                                GlobalVariables.aliasInParameter.Add($"\"{command.Trim()}\"");
-                            else 
-                                GlobalVariables.aliasInParameter.Add(command.Trim());
-                        }
-                }
             }
 
             if (!s_terminalCommands.TryGetValue(commandName, out terminalCommandOut)
@@ -119,7 +119,7 @@ namespace Commands
                     {
                         Console.WriteLine($"Unknown command: {commandLine}");
                     }
-                    GlobalVariables.aliasParameters = " ";
+                    /GlobalVariables.aliasParameters = " ";
                 }
             }
             return terminalCommandOut;
@@ -157,10 +157,10 @@ namespace Commands
                 GlobalVariables.isSingleAlias = true;
                 var concatanate = "";
                 for (int i = 0; i < countItems; i++)
-                    concatanate+=$"{GlobalVariables.aliasInParameter[i]}";
+                    concatanate += $"{GlobalVariables.aliasInParameter[i]}";
                 command = concatanate.Trim();
             }
-            else 
+            else
                 for (int i = 0; i < countItems; i++)
                     command = command.Replace($"%{i + 1}", GlobalVariables.aliasInParameter[i]);
 

--- a/Commands/CommandRepository.cs
+++ b/Commands/CommandRepository.cs
@@ -8,7 +8,6 @@ using Json = Core.SystemTools.JsonManage;
 using AliasC = Core.SystemTools.AliasC;
 using Core.SystemTools;
 using System.Runtime.Versioning;
-using System.Reflection.Metadata;
 
 namespace Commands
 {

--- a/Commands/Properties/AssemblyInfo.cs
+++ b/Commands/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Commands")]
-[assembly: AssemblyCopyright("Copyright ©  2020-2023 0x78654c")]
+[assembly: AssemblyCopyright("Copyright ©  2020-2024 0x78654c")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Commands/Properties/AssemblyInfo.cs
+++ b/Commands/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.7.2.0")]
-[assembly: AssemblyFileVersion("1.7.2.0")]
+[assembly: AssemblyVersion("1.7.3.0")]
+[assembly: AssemblyFileVersion("1.7.3.0")]

--- a/Commands/Properties/AssemblyInfo.cs
+++ b/Commands/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.7.3.0")]
-[assembly: AssemblyFileVersion("1.7.3.0")]
+[assembly: AssemblyVersion("1.7.4.0")]
+[assembly: AssemblyFileVersion("1.7.4.0")]

--- a/Commands/TerminalCommands/ConsoleSystem/Help.cs
+++ b/Commands/TerminalCommands/ConsoleSystem/Help.cs
@@ -52,8 +52,7 @@ This is the full list of commands that can be used in xTerminal:
     mv        -- Renames a file or directory in a specific directory(s).
                  Example: mv <old_file/dir_name> -o <new_file/dir_name>
     fmove     -- Moves a file with CRC checksum control. Use -h for additional parameters.
-    edit      -- Opens a file in Notepad(default). 
-                 To set a new text editor you must use following command: edit set ""Path to editor""
+    edit      -- Sets a text editor for open files(default is notpead). Use -h for additional help.
     del       -- Deletes a file or folder without recover.  Use -h for additional parameters.
     cp        -- Check file/folder permissions.
     md5       -- Checks the md5 checksum of a file. Use -h for additional help.

--- a/Commands/TerminalCommands/DirFiles/Editor.cs
+++ b/Commands/TerminalCommands/DirFiles/Editor.cs
@@ -11,6 +11,8 @@ namespace Commands.TerminalCommands.DirFiles
     {
         public string Name => "edit";
         private static string s_helpMessage = @"Usage of edit command:
+Usage: edit <file_path>
+Parameters:
     -set     : Sets the text editor you want to use. (Default is notepad)
                Example: edit -set <path_to_editor_binary>
     -current : Displays the current used editor.

--- a/Commands/TerminalCommands/DirFiles/Editor.cs
+++ b/Commands/TerminalCommands/DirFiles/Editor.cs
@@ -10,7 +10,12 @@ namespace Commands.TerminalCommands.DirFiles
     public class Editor : ITerminalCommand
     {
         public string Name => "edit";
-
+        private static string s_helpMessage = @"Usage of edit command:
+    -set     : Sets the text editor you want to use. (Default is notepad)
+               Example: edit -set <path_to_editor_binary>
+    -current : Displays the current used editor.
+    -h       : Displays this message.
+";
         public void Execute(string arg)
         {
             string file = string.Empty;
@@ -18,14 +23,25 @@ namespace Commands.TerminalCommands.DirFiles
             string dlocation = File.ReadAllText(GlobalVariables.currentDirectory);
             string cEditor = RegistryManagement.regKey_Read(GlobalVariables.regKeyName, GlobalVariables.regCurrentEitor);
 
+
+            // Set default editor if none is set.
             if (cEditor == "")
-            {
                 RegistryManagement.regKey_WriteSubkey(GlobalVariables.regKeyName, GlobalVariables.regCurrentEitor, "notepad");
-            }
 
             try
             {
-                if (!arg.Contains("set"))
+                if(arg == "edit -h".Trim())
+                {
+                    Console.WriteLine(s_helpMessage);
+                    return;
+                }
+                if (arg.Contains("-current"))
+                {
+                    string currentEditor = RegistryManagement.regKey_Read(GlobalVariables.regKeyName, GlobalVariables.regCurrentEitor);
+                    FileSystem.SuccessWriteLine("Your current editor is: " + currentEditor);
+                    return;
+                }
+                if (!arg.Contains("-set"))
                 {
                     int argLenght = arg.Length - 5;
                     if (GlobalVariables.isPipeCommand)
@@ -36,7 +52,7 @@ namespace Commands.TerminalCommands.DirFiles
                     ProcessCall(file, File.Exists(cEditor) ? cEditor : "notepad");
                     return;
                 }
-                set = arg.Replace("edit set ", "");
+                set = arg.Replace("edit -set ", "");
                 if (File.Exists(set))
                 {
                     RegistryManagement.regKey_WriteSubkey(GlobalVariables.regKeyName, GlobalVariables.regCurrentEitor, set);

--- a/Core/GlobalVariables.cs
+++ b/Core/GlobalVariables.cs
@@ -22,6 +22,7 @@ namespace Core
         public static string commandOut { get; set; }
         public static string version { get; set; }
         public static string aliasParameters = string.Empty;
+        public static bool isSingleAlias { get; set; } = false;
         public static readonly string accountName = Environment.UserName;
         public static string rootPath = $"{Path.GetPathRoot(Environment.SystemDirectory)}Users\\{accountName}\\";
         public static readonly string computerName = Environment.MachineName;

--- a/Core/GlobalVariables.cs
+++ b/Core/GlobalVariables.cs
@@ -22,7 +22,6 @@ namespace Core
         public static string commandOut { get; set; }
         public static string version { get; set; }
         public static string aliasParameters = string.Empty;
-        public static bool isSingleAlias { get; set; } = false;
         public static readonly string accountName = Environment.UserName;
         public static string rootPath = $"{Path.GetPathRoot(Environment.SystemDirectory)}Users\\{accountName}\\";
         public static readonly string computerName = Environment.MachineName;

--- a/Core/Properties/AssemblyInfo.cs
+++ b/Core/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Core")]
-[assembly: AssemblyCopyright("Copyright ©  2020-2023 0x78654c")]
+[assembly: AssemblyCopyright("Copyright ©  2020-2024 0x78654c")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Core/eMailS.cs
+++ b/Core/eMailS.cs
@@ -29,7 +29,7 @@ namespace Core
                     string _smtp = SmtpCheck(senderEmail);
                     if (_smtp == "No valid SMTP Server")
                     {
-                        Console.WriteLine($"[{_date}] No valid SMTP Server. Accepted email clients are: Microsoft(live, hotmail, outlook), Yahoo and Gmail!");
+                        FileSystem.ErrorWriteLine($"[{_date}] No valid SMTP Server. Accepted email clients are: Microsoft(live, hotmail, outlook), Yahoo and Gmail!");
                         return;
                     }
 
@@ -51,7 +51,7 @@ namespace Core
                     try
                     {
                         client.Send(msg);
-                        Console.WriteLine($"[{_date}] Email sent to " + receiverEmail);
+                        FileSystem.SuccessWriteLine($"[{_date}] Email sent to " + receiverEmail);
                     }
                     catch (Exception e)
                     {
@@ -60,7 +60,7 @@ namespace Core
                 }
                 else
                 {
-                    Console.WriteLine($"[{_date}] No internet connection!");
+                    FileSystem.ErrorWriteLine($"[{_date}] No internet connection!");
                 }
             }
             catch (Exception e)

--- a/README.md
+++ b/README.md
@@ -174,7 +174,11 @@ This is the full list of commands that can be used in xTerminal:
                  Example: mv <old_file/dir_name> -o <new_file/dir_name>
     fmove     -- Moves a file with CRC checksum control. Use -h for additional parameters.
                    -ma <destination_directory> : moves all files from current directory in a specific directory
-    edit      -- Opens a file in Notepad(default). To set a new text editor you must use following command: edit set ""Path to editor""
+    edit      -- Sets a text editor for open files(default is notpead). Usage: edit <file_path>
+                   -set     : Sets the text editor you want to use. (Default is notepad)
+                              Example: edit -set <path_to_editor_binary>
+                   -current : Displays the current used editor.
+                   -h       : Displays this message.
     del       -- Deletes a file or folder without recover. Use -h for additional parameters.
                    -h  : Displayes this message. 
                    -a  : Deletes all files and directories in current directory. 

--- a/Shell/Properties/AssemblyInfo.cs
+++ b/Shell/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.7.9.0")]
-[assembly: AssemblyFileVersion("1.7.9.0")]
+[assembly: AssemblyVersion("1.8.0.0")]
+[assembly: AssemblyFileVersion("1.8.0.0")]


### PR DESCRIPTION
Added -current parameter to edit command for display current editor used.
Added -h parameter for display the help message.
Now set parameter is changed to -set for edit command.
Fix: It can be used in parameters with quotes and exclamation mark in begging !"hello world " for string that includes space but double quotes are not needed. Works only with alias commands with multi parameters.